### PR TITLE
feat: portfolio redesign with bento grid and violet accent

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,25 +1,29 @@
 @import "tailwindcss";
 
 @theme {
-  --color-bg: #09090b;
-  --color-surface: #111113;
-  --color-elevated: #1a1a1e;
-  --color-border: #1f1f23;
-  --color-border-hover: #2e2e35;
-  --color-text: #ededed;
-  --color-muted: #888888;
-  --color-dim: #555555;
-  --color-green: #4ade80;
+  --color-bg: #0a0a0f;
+  --color-surface: #111118;
+  --color-elevated: #18181f;
+  --color-border: #242430;
+  --color-border-hover: #363648;
+  --color-text: #f2f2f8;
+  --color-muted: #9090a8;
+  --color-dim: #505068;
+  --color-violet: #7c3aed;
+  --color-violet-light: #a78bfa;
+  --color-violet-dim: #5b21b6;
+  --color-violet-tint: rgba(124, 58, 237, 0.08);
+  --color-violet-glow: rgba(124, 58, 237, 0.15);
+  --color-green: #4ade80;     /* keep for code syntax highlighting */
   --color-green-dim: #22c55e;
   --color-green-tint: rgba(74, 222, 128, 0.08);
-  --color-green-glow: rgba(74, 222, 128, 0.12);
   --color-purple: #c084fc;
   --color-cyan: #22d3ee;
   --color-yellow: #fbbf24;
   --color-rose: #fb7185;
   --color-amber: #f59e0b;
-  --font-sans: "Outfit", -apple-system, system-ui, sans-serif;
-  --font-display: "Syne", sans-serif;
+  --font-sans: "DM Sans", -apple-system, system-ui, sans-serif;
+  --font-display: "DM Serif Display", serif;
   --font-mono: "JetBrains Mono", "Fira Code", monospace;
 }
 
@@ -33,7 +37,7 @@ body {
 }
 
 ::selection {
-  background-color: rgba(74, 222, 128, 0.2);
+  background-color: rgba(124, 58, 237, 0.2);
   color: var(--color-text);
 }
 
@@ -73,7 +77,7 @@ body::after {
   transform: translateX(-50%);
   width: 900px;
   height: 600px;
-  background: radial-gradient(ellipse at center, rgba(74, 222, 128, 0.07) 0%, rgba(34, 211, 238, 0.03) 40%, transparent 70%);
+  background: radial-gradient(ellipse at center, rgba(124, 58, 237, 0.08) 0%, rgba(167, 139, 250, 0.04) 40%, transparent 70%);
   pointer-events: none;
   z-index: 0;
 }
@@ -81,7 +85,7 @@ body::after {
 /* ── Scroll progress ── */
 .scroll-bar {
   transform-origin: left;
-  background: linear-gradient(90deg, var(--color-green), var(--color-cyan), var(--color-green-dim));
+  background: linear-gradient(90deg, var(--color-violet), var(--color-violet-light), var(--color-violet-dim));
 }
 
 /* ── Blinking cursor ── */
@@ -93,7 +97,7 @@ body::after {
   display: inline-block;
   width: 2px;
   height: 1.15em;
-  background: var(--color-green);
+  background: var(--color-violet-light);
   margin-left: 1px;
   animation: blink 0.75s step-end infinite;
   vertical-align: text-bottom;
@@ -118,9 +122,36 @@ body::after {
   transition: border-color 0.3s, box-shadow 0.3s, background-color 0.3s;
 }
 .card:hover, .card-glow:hover {
-  border-color: rgba(74, 222, 128, 0.3);
-  box-shadow: 0 8px 40px rgba(74, 222, 128, 0.06), 0 2px 8px rgba(0,0,0,0.4);
+  border-color: rgba(124, 58, 237, 0.3);
+  box-shadow: 0 8px 40px rgba(124, 58, 237, 0.08), 0 2px 8px rgba(0,0,0,0.4);
   background: var(--color-elevated);
+}
+
+/* ── Bento Grid ── */
+.bento-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 1rem;
+}
+.bento-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  overflow: hidden;
+  transition: border-color 0.3s, box-shadow 0.3s, background-color 0.3s;
+  position: relative;
+}
+.bento-card:hover {
+  border-color: rgba(124, 58, 237, 0.35);
+  box-shadow: 0 12px 48px rgba(124, 58, 237, 0.1), 0 2px 8px rgba(0,0,0,0.4);
+  background: var(--color-elevated);
+}
+.bento-col-7 { grid-column: span 7; }
+.bento-col-5 { grid-column: span 5; }
+.bento-col-12 { grid-column: span 12; }
+.bento-col-6 { grid-column: span 6; }
+@media (max-width: 768px) {
+  .bento-col-7, .bento-col-5, .bento-col-6 { grid-column: span 12; }
 }
 
 /* ── Code block ── */
@@ -132,8 +163,8 @@ body::after {
   box-shadow: 0 4px 24px rgba(0,0,0,0.3);
 }
 .code-block-accent {
-  border-left: 3px solid var(--color-green);
-  box-shadow: -4px 0 20px rgba(74, 222, 128, 0.08);
+  border-left: 3px solid var(--color-violet);
+  box-shadow: -4px 0 20px rgba(124, 58, 237, 0.1);
 }
 .code-block .titlebar {
   background: var(--color-elevated);
@@ -155,9 +186,9 @@ body::after {
   font-size: 11px;
   padding: 3px 10px;
   border-radius: 6px;
-  background: var(--color-green-tint);
-  color: var(--color-green);
-  border: 1px solid rgba(74, 222, 128, 0.12);
+  background: var(--color-violet-tint);
+  color: var(--color-violet-light);
+  border: 1px solid rgba(124, 58, 237, 0.2);
   transition: all 0.2s;
   white-space: nowrap;
 }
@@ -225,7 +256,7 @@ body::after {
   transition: background 0.3s;
 }
 .exp-entry:hover::before {
-  background: linear-gradient(to bottom, var(--color-green), var(--color-border));
+  background: linear-gradient(to bottom, var(--color-violet), var(--color-border));
 }
 .exp-dot {
   position: absolute;
@@ -240,12 +271,12 @@ body::after {
   z-index: 1;
 }
 .exp-dot-active {
-  background: var(--color-green);
-  box-shadow: 0 0 12px rgba(74, 222, 128, 0.5);
+  background: var(--color-violet);
+  box-shadow: 0 0 12px rgba(124, 58, 237, 0.5);
 }
 .exp-entry-current {
-  background: var(--color-green-tint);
-  border: 1px solid rgba(74, 222, 128, 0.15);
+  background: var(--color-violet-tint);
+  border: 1px solid rgba(124, 58, 237, 0.15);
   border-radius: 12px;
   padding: 1.25rem 1.25rem 1.25rem 1.5rem;
 }
@@ -258,7 +289,7 @@ body::after {
   opacity: 0.7;
   transition: opacity 0.3s;
 }
-.card:hover .project-card-accent {
+.card:hover .project-card-accent, .bento-card:hover .project-card-accent {
   opacity: 1;
 }
 
@@ -287,14 +318,14 @@ body::after {
   position: absolute;
   inset: 0;
   border-radius: 50%;
-  background: var(--color-green);
+  background: var(--color-violet);
   animation: pulse-ring 2s ease-out infinite;
 }
 
 /* ── Footer gradient line ── */
 .footer-line {
   height: 1px;
-  background: linear-gradient(90deg, transparent 0%, var(--color-green) 30%, var(--color-cyan) 60%, transparent 100%);
+  background: linear-gradient(90deg, transparent 0%, var(--color-violet) 30%, var(--color-violet-light) 60%, transparent 100%);
   margin-bottom: 0;
   opacity: 0.4;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -60,11 +60,11 @@ export default function RootLayout({
   return (
     <html lang="en" className="scroll-smooth">
       <head>
-        <meta name="theme-color" content="#09090b" />
+        <meta name="theme-color" content="#0a0a0f" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
-          href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=Outfit:wght@400;500;600;700&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap"
+          href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,700;1,9..40,400&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap"
           rel="stylesheet"
         />
         <link rel="alternate" hrefLang="en" href="https://jonathanperis.github.io/" />

--- a/app/portfolio.tsx
+++ b/app/portfolio.tsx
@@ -72,7 +72,7 @@ function Reveal({ children, className = '', delay = 0 }: { children: React.React
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex items-center gap-3 mb-10">
-      <span className="font-mono text-xs font-bold uppercase tracking-widest text-green">{children}</span>
+      <span className="font-mono text-xs font-bold uppercase tracking-widest" style={{ color: 'var(--color-violet-light)' }}>{children}</span>
       <span className="section-label-line" />
     </div>
   );
@@ -194,41 +194,41 @@ export default function Portfolio({ projects }: { projects: GitHubRepo[] }) {
       {/* Scroll progress */}
       <div className="scroll-bar fixed top-0 left-0 right-0 h-[2px] z-50" style={{ transform: `scaleX(${scrollProgress})` }} />
 
-      <div className="relative z-10 mx-auto max-w-3xl px-6 md:px-8">
+      <div className="relative z-10 mx-auto max-w-6xl px-6 md:px-12">
 
         {/* ━━ Nav ━━ */}
-        <nav className="sticky top-0 z-40 -mx-6 md:-mx-8 px-6 md:px-8 py-4 bg-bg/80 backdrop-blur-lg border-b border-transparent" style={{ borderColor: scrollProgress > 0.02 ? 'var(--color-border)' : 'transparent' }}>
-          <div className="flex items-center justify-between max-w-3xl mx-auto">
-            <a href="/" className="font-mono text-sm font-bold text-text hover:text-green transition-colors">jp<span className="text-green">.</span></a>
+        <nav className="sticky top-0 z-40 -mx-6 md:-mx-12 px-6 md:px-12 py-4 bg-bg/80 backdrop-blur-lg border-b border-transparent" style={{ borderColor: scrollProgress > 0.02 ? 'var(--color-border)' : 'transparent' }}>
+          <div className="flex items-center justify-between max-w-6xl mx-auto">
+            <a href="/" className="font-mono text-sm font-bold text-text hover:text-violet transition-colors">jp<span style={{ color: 'var(--color-violet)' }}>.</span></a>
             <div className="flex items-center gap-6">
               {["about", "experience", "projects"].map((s) => (
                 <a key={s} href={`#${s}`} className="font-mono text-xs text-dim hover:text-text transition-colors">{s}</a>
               ))}
-              <a href="/resume" className="font-mono text-xs text-bg bg-green hover:bg-green-dim px-3 py-1 rounded-md transition-colors font-semibold">resume</a>
+              <a href="/resume" className="font-mono text-xs text-bg px-3 py-1 rounded-md transition-colors font-semibold" style={{ color: 'var(--color-bg)', background: 'var(--color-violet)' }} onMouseOver={e => e.currentTarget.style.background = 'var(--color-violet-dim)'} onMouseOut={e => e.currentTarget.style.background = 'var(--color-violet)'}>resume</a>
             </div>
           </div>
         </nav>
 
         {/* ━━ Hero ━━ */}
-        <section className="relative pt-24 pb-20 md:pt-32 md:pb-28 overflow-visible">
+        <section className="relative pt-24 pb-20 md:pt-32 md:pb-28 overflow-visible max-w-4xl">
           <div className="hero-glow" aria-hidden="true" />
           <Reveal>
-            <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-green/20 bg-green-tint px-3 py-1">
+            <div className="mb-6 inline-flex items-center gap-2 rounded-full border px-3 py-1" style={{ borderColor: 'rgba(124,58,237,0.2)', backgroundColor: 'var(--color-violet-tint)' }}>
               <span className="relative flex h-2 w-2">
-                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green opacity-60" />
-                <span className="relative inline-flex h-2 w-2 rounded-full bg-green" />
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full opacity-60" style={{ backgroundColor: 'var(--color-violet)' }} />
+                <span className="relative inline-flex h-2 w-2 rounded-full" style={{ backgroundColor: 'var(--color-violet)' }} />
               </span>
-              <span className="font-mono text-xs text-green">Available for hire</span>
+              <span className="font-mono text-xs" style={{ color: 'var(--color-violet)' }}>Available for hire</span>
             </div>
           </Reveal>
           <Reveal delay={100}>
-            <h1 style={{ fontFamily: 'var(--font-display)' }} className="text-5xl md:text-7xl font-extrabold tracking-tight text-text leading-[1.05]">
+            <h1 style={{ fontFamily: 'var(--font-display)' }} className="text-6xl md:text-8xl font-extrabold tracking-tight text-text leading-[1.05]">
               Jonathan Peris
             </h1>
           </Reveal>
           <Reveal delay={200}>
             <p className="mt-4 font-mono text-lg md:text-xl h-8">
-              <span className="text-green">{typedRole}</span>
+              <span style={{ color: 'var(--color-violet-light)' }}>{typedRole}</span>
               <span className="typing-cursor" />
             </p>
           </Reveal>
@@ -238,10 +238,10 @@ export default function Portfolio({ projects }: { projects: GitHubRepo[] }) {
             </p>
           </Reveal>
           <Reveal delay={400}>
-            <div className="mt-8 flex items-center gap-4">
+            <div className="mt-8 flex items-center gap-4 group">
               {SOCIALS.map((s) => (
                 <a key={s.label} href={s.href} target="_blank" rel="noreferrer noopener" aria-label={s.label} title={s.label}
-                  className="text-dim hover:text-green transition-colors duration-300">
+                  className="text-dim transition-colors duration-300" onMouseOver={e => e.currentTarget.style.color = 'var(--color-violet)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-dim)'}>
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox={s.vb} fill="currentColor" className="h-5 w-5"><path d={s.icon} /></svg>
                 </a>
               ))}
@@ -296,7 +296,7 @@ export default function Portfolio({ projects }: { projects: GitHubRepo[] }) {
         {/* ━━ Stack ━━ */}
         <section className="py-16 scroll-mt-20">
           <Reveal><SectionLabel>// stack</SectionLabel></Reveal>
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid gap-3 sm:grid-cols-2 max-w-4xl">
             {SKILL_CATEGORIES.map(({ key, label, tagClass }, i) => (
               <Reveal key={key} delay={i * 60}>
                 <div className="card p-4 h-full">
@@ -315,7 +315,7 @@ export default function Portfolio({ projects }: { projects: GitHubRepo[] }) {
         {/* ━━ Experience ━━ */}
         <section id="experience" className="py-16 scroll-mt-20">
           <Reveal><SectionLabel>Experience</SectionLabel></Reveal>
-          <div className="relative pl-4 space-y-1">
+          <div className="relative pl-4 space-y-1 max-w-4xl">
             {EXPERIENCES.map((exp, i) => (
               <Reveal key={`${exp.company}-${exp.period}`} delay={i * 60}>
                 <div className={`exp-entry group ${i === 0 ? 'exp-entry-current' : 'py-5'}`}>
@@ -341,41 +341,51 @@ export default function Portfolio({ projects }: { projects: GitHubRepo[] }) {
         {/* ━━ Featured Projects ━━ */}
         <section id="projects" className="py-16 scroll-mt-20">
           <Reveal><SectionLabel>Featured Projects</SectionLabel></Reveal>
-          <div className="space-y-4">
-            {FEATURED_PROJECTS.map((fp, i) => (
-              <Reveal key={fp.slug} delay={i * 80}>
-                <div className="card card-glow overflow-hidden group">
-                  <div className="project-card-accent" style={{ background: fp.langColor }} />
-                  <div className="p-6">
-                    <div className="flex items-center gap-2 mb-3">
-                      <span className="h-3 w-3 rounded-full flex-shrink-0" style={{ backgroundColor: fp.langColor }} />
-                      <h3 style={{ fontFamily: 'var(--font-display)' }} className="text-lg font-bold text-text group-hover:text-green transition-colors">{fp.name}</h3>
-                      <span className="font-mono text-xs text-dim ml-1">{fp.lang}</span>
-                    </div>
-                    <p className="text-sm text-muted leading-relaxed mb-4">{fp.description}</p>
-                    <div className="flex flex-wrap gap-1.5 mb-4">
-                      {fp.tags.map((t) => (<span key={t} className="tag">{t}</span>))}
-                    </div>
-                    <div className="flex items-center gap-3">
-                      <a href={fp.repoUrl} target="_blank" rel="noreferrer noopener"
-                        className="inline-flex items-center gap-1.5 font-mono text-xs text-muted hover:text-green transition-colors">
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
-                          <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-                        </svg>
-                        Source Code
-                      </a>
-                      <a href={fp.liveUrl} target="_blank" rel="noreferrer noopener"
-                        className="inline-flex items-center gap-1.5 font-mono text-xs font-semibold text-green border border-green/20 bg-green-tint rounded-md px-2.5 py-1 hover:bg-green/20 transition-colors">
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-3.5 w-3.5">
-                          <path fillRule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5zm7.25-.182a.75.75 0 01.75-.75h3.5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0V6.56l-5.22 5.22a.75.75 0 11-1.06-1.06l5.22-5.22h-2.44a.75.75 0 01-.75-.75z" clipRule="evenodd" />
-                        </svg>
-                        Visit website
-                      </a>
+          <div className="bento-grid">
+            {FEATURED_PROJECTS.map((fp, i) => {
+              // Assign bento column spans — alternate between wide/narrow
+              const colSpan = i % 3 === 0 ? 'bento-col-7' : i % 3 === 1 ? 'bento-col-5' : 'bento-col-12';
+              const isWide = i % 3 === 2;
+              return (
+                <Reveal key={fp.slug} delay={i * 80} className={colSpan}>
+                  <div className="bento-card h-full group">
+                    <div className="project-card-accent" style={{ background: fp.langColor }} />
+                    <div className={`p-6 h-full flex flex-col ${isWide ? 'md:flex-row md:gap-6 md:items-center' : ''}`}>
+                      <div className={isWide ? 'flex-1' : 'flex-1'}>
+                        <div className="flex items-center gap-2 mb-3">
+                          <span className="h-3 w-3 rounded-full flex-shrink-0" style={{ backgroundColor: fp.langColor }} />
+                          <h3 style={{ fontFamily: 'var(--font-display)' }} className="text-lg font-bold text-text transition-colors" onMouseOver={e => e.currentTarget.style.color = 'var(--color-violet-light)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-text)'}>{fp.name}</h3>
+                          <span className="font-mono text-xs text-dim ml-1">{fp.lang}</span>
+                        </div>
+                        <p className="text-sm text-muted leading-relaxed mb-4">{fp.description}</p>
+                        <div className="flex flex-wrap gap-1.5 mb-4">
+                          {fp.tags.map((t) => (<span key={t} className="tag">{t}</span>))}
+                        </div>
+                      </div>
+                      <div className={`flex items-center gap-3 mt-auto pt-4 ${isWide ? 'md:flex-col md:items-end md:justify-center md:pt-0' : ''}`}>
+                        <a href={fp.repoUrl} target="_blank" rel="noreferrer noopener"
+                          className="inline-flex items-center gap-1.5 font-mono text-xs text-muted transition-colors" onMouseOver={e => e.currentTarget.style.color = 'var(--color-text)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-muted)'}>
+                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
+                            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+                          </svg>
+                          Source Code
+                        </a>
+                        <a href={fp.liveUrl} target="_blank" rel="noreferrer noopener"
+                          className="inline-flex items-center gap-1.5 font-mono text-xs font-semibold border rounded-md px-2.5 py-1 transition-colors"
+                          style={{ color: 'var(--color-violet-light)', borderColor: 'rgba(124,58,237,0.3)', background: 'var(--color-violet-tint)' }}
+                          onMouseOver={e => e.currentTarget.style.background = 'rgba(124,58,237,0.15)'}
+                          onMouseOut={e => e.currentTarget.style.background = 'var(--color-violet-tint)'}>
+                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-3.5 w-3.5">
+                            <path fillRule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5zm7.25-.182a.75.75 0 01.75-.75h3.5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0V6.56l-5.22 5.22a.75.75 0 11-1.06-1.06l5.22-5.22h-2.44a.75.75 0 01-.75-.75z" clipRule="evenodd" />
+                          </svg>
+                          Visit website
+                        </a>
+                      </div>
                     </div>
                   </div>
-                </div>
-              </Reveal>
-            ))}
+                </Reveal>
+              );
+            })}
           </div>
         </section>
 
@@ -388,10 +398,10 @@ export default function Portfolio({ projects }: { projects: GitHubRepo[] }) {
                 <a href={p.url} target="_blank" rel="noreferrer noopener"
                   className="card card-glow p-5 block group h-full">
                   <div className="flex items-center gap-2 mb-2">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-4 w-4 text-dim group-hover:text-green transition-colors flex-shrink-0">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-4 w-4 text-dim transition-colors flex-shrink-0" onMouseOver={e => e.currentTarget.style.color = 'var(--color-violet)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-dim)'}>
                       <path d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5zm10.5-1h-8a1 1 0 00-1 1v6.708A2.486 2.486 0 014.5 9h8.5zM5 12.25v3.25a.25.25 0 00.4.2l1.45-1.087a.25.25 0 01.3 0L8.6 15.7a.25.25 0 00.4-.2v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25z" />
                     </svg>
-                    <span className="font-mono text-sm font-semibold text-text group-hover:text-green transition-colors">{p.title}</span>
+                    <span className="font-mono text-sm font-semibold text-text transition-colors" onMouseOver={e => e.currentTarget.style.color = 'var(--color-violet)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-text)'}>{p.title}</span>
                     {p.stars > 0 && (
                       <span className="ml-auto flex items-center gap-1 text-xs text-dim font-mono">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3">
@@ -410,7 +420,10 @@ export default function Portfolio({ projects }: { projects: GitHubRepo[] }) {
                     {p.homepageUrl && (
                       <span
                         onClick={(e) => { e.preventDefault(); e.stopPropagation(); window.open(p.homepageUrl, '_blank'); }}
-                        className="inline-flex items-center gap-1 font-mono text-[10px] font-semibold text-green border border-green/20 bg-green-tint rounded-md px-2 py-0.5 hover:bg-green/20 transition-colors cursor-pointer"
+                        className="inline-flex items-center gap-1 font-mono text-[10px] font-semibold border rounded-md px-2 py-0.5 transition-colors cursor-pointer"
+                        style={{ color: 'var(--color-violet-light)', borderColor: 'rgba(124,58,237,0.3)', background: 'var(--color-violet-tint)' }}
+                        onMouseOver={e => e.currentTarget.style.background = 'rgba(124,58,237,0.15)'}
+                        onMouseOut={e => e.currentTarget.style.background = 'var(--color-violet-tint)'}
                       >
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-3 w-3">
                           <path fillRule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5zm7.25-.182a.75.75 0 01.75-.75h3.5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0V6.56l-5.22 5.22a.75.75 0 11-1.06-1.06l5.22-5.22h-2.44a.75.75 0 01-.75-.75z" clipRule="evenodd" />
@@ -426,7 +439,7 @@ export default function Portfolio({ projects }: { projects: GitHubRepo[] }) {
           <Reveal delay={400}>
             <div className="mt-8 text-center">
               <a href="https://github.com/jonathanperis" target="_blank" rel="noreferrer noopener"
-                className="inline-flex items-center gap-2 font-mono text-sm text-muted hover:text-green transition-colors">
+                className="inline-flex items-center gap-2 font-mono text-sm text-muted transition-colors" onMouseOver={e => e.currentTarget.style.color = 'var(--color-violet-light)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-muted)'}>
                 View all on GitHub
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
                   <path fillRule="evenodd" d="M5.22 14.78a.75.75 0 001.06 0l7.22-7.22v5.69a.75.75 0 001.5 0v-7.5a.75.75 0 00-.75-.75h-7.5a.75.75 0 000 1.5h5.69l-7.22 7.22a.75.75 0 000 1.06z" clipRule="evenodd" />
@@ -449,16 +462,16 @@ export default function Portfolio({ projects }: { projects: GitHubRepo[] }) {
               <div className="flex items-center justify-center gap-5">
                 {SOCIALS.map((s) => (
                   <a key={s.label} href={s.href} target="_blank" rel="noreferrer noopener" title={s.label}
-                    className="text-dim hover:text-green transition-colors">
+                    className="text-dim transition-colors" onMouseOver={e => e.currentTarget.style.color = 'var(--color-violet-light)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-dim)'}>
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox={s.vb} fill="currentColor" className="h-4 w-4"><path d={s.icon} /></svg>
                   </a>
                 ))}
               </div>
               <p className="font-mono text-xs text-dim">
                 Built with ❤️ by{' '}
-                <a href="https://github.com/jonathanperis" target="_blank" rel="noreferrer noopener" className="font-bold text-dim hover:text-green transition-colors">Me</a>
+                <a href="https://github.com/jonathanperis" target="_blank" rel="noreferrer noopener" className="font-bold text-dim transition-colors" onMouseOver={e => e.currentTarget.style.color = 'var(--color-violet-light)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-dim)'}>Me</a>
                 {' '}and my{' '}
-                <a href="https://claude.ai/" target="_blank" rel="noreferrer noopener" className="font-bold text-dim hover:text-green transition-colors">24/7 Intern</a>
+                <a href="https://claude.ai/" target="_blank" rel="noreferrer noopener" className="font-bold text-dim transition-colors" onMouseOver={e => e.currentTarget.style.color = 'var(--color-violet-light)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-dim)'}>24/7 Intern</a>
               </p>
               {/* eslint-disable-next-line react/no-unescaped-entities */}
               <p className="font-mono text-[10px] text-dim/30 select-none">{"// ↑↑↓↓←→←→BA"}</p>
@@ -471,7 +484,7 @@ export default function Portfolio({ projects }: { projects: GitHubRepo[] }) {
       {termOpen && (
         <div className="fixed inset-0 z-50 terminal-backdrop flex items-center justify-center p-4"
           onClick={(e) => { if (e.target === e.currentTarget) setTermOpen(false); }}>
-          <div className="w-full max-w-2xl rounded-xl border border-border overflow-hidden shadow-2xl shadow-green/5">
+          <div className="w-full max-w-2xl rounded-xl border border-border overflow-hidden shadow-2xl shadow-violet/5">
             <div className="flex items-center gap-2 bg-elevated px-4 py-3 border-b border-border">
               <div className="flex gap-1.5">
                 <button onClick={() => setTermOpen(false)} className="h-3 w-3 rounded-full bg-[#ff5f57] hover:brightness-110 transition" aria-label="Close" />


### PR DESCRIPTION
## Summary

- Complete visual redesign of the portfolio with a bold **BENTO PORTFOLIO** aesthetic
- Typography overhaul: **DM Serif Display** (display/headings) + **DM Sans** (body) + **JetBrains Mono** (code/mono)
- Accent color: vivid **violet** (`#7c3aed` / `#a78bfa`) replaces green across all interactive elements
- Featured Projects now rendered as an asymmetric **bento grid** (2-col, 12-column system with varying `span 5/7/12` widths)
- Full-width layout: `max-w-6xl` container replaces the previous narrow `max-w-3xl`

## Preserved (unchanged)
- `useTyping`, `useReveal`, `useScrollProgress` hooks — verbatim
- Terminal easter egg + Konami code (`↑↑↓↓←→←→BA`) + all terminal commands
- `Reveal` component, `runCmd`, `NEOFETCH`, `SKILL_CATEGORIES`
- GitHub API `projects` prop and More Projects section
- All SOCIALS, EXPERIENCES, FEATURED_PROJECTS from `data.ts` (not modified)
- Resume link, scroll progress bar, typing animation cursor

## Files changed
- `app/layout.tsx` — fonts + theme-color only
- `app/globals.css` — full rewrite with violet design system + bento grid CSS
- `app/portfolio.tsx` — full rewrite preserving all features/hooks/logic

## Notes
Tagged `v5.0.0` on main before this branch was created. TypeScript compiles clean (`tsc --noEmit` passes).