### PR TITLE
chore: consolidate deploy workflow to single-job GitHub Pages model

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,55 +2,38 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: ["main"]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
-  contents: read
   pages: write
   id-token: write
+  contents: read
 
 concurrency:
-  group: "pages"
+  group: github-pages
   cancel-in-progress: false
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-          cache: "npm"
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEXT_PUBLIC_GA_ID: G-35CN95481D
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: ./out
-
   deploy:
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+      - uses: actions/configure-pages@v6
+      - run: npm ci
+      - run: npm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEXT_PUBLIC_GA_ID: G-35CN95481D
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./out
+      - id: deployment
         uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- Consolidates the two-job (build → deploy) workflow into a single-job pattern, matching the [speedy-bird-lynx deploy model](https://github.com/jonathanperis/speedy-bird-lynx/blob/main/.github/workflows/deploy-web.yml)
- Bumps Node.js from 20 to 22
- Removes verbose step names for a cleaner workflow
- Updates concurrency group to `github-pages`

## Test plan
- [ ] CI passes (lint + build)
- [ ] Merge and verify GitHub Pages deployment succeeds via the new single-job workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)