### PR TITLE
docs: add sync main steps to development workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,11 +124,13 @@ jonathanperis.github.io/
 
 ## Development Workflow
 
-1. Create a feature branch from `main`
-2. Make changes and push
-3. Open a PR targeting `main` — CI runs lint + build automatically
-4. After review and green checks, rebase-merge the PR
-5. `deploy.yml` triggers automatically on push to main
+1. **Sync main first:** `git fetch origin main && git checkout main && git pull origin main`
+2. Create a feature branch from `main`
+3. Make changes and push
+4. **Before opening a PR:** fetch and pull main again to ensure no conflicts
+5. Open a PR targeting `main` — CI runs lint + build automatically
+6. After review and green checks, rebase-merge the PR
+7. `deploy.yml` triggers automatically on push to main
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds explicit steps to the Development Workflow in CLAUDE.md requiring fetch/pull of main before creating branches and before opening PRs
- Prevents merge conflicts from stale local main branches

## Test plan
- [ ] CI passes (lint + build)
- [ ] Verify CLAUDE.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)