### PR TITLE
chore: rename workflows to build-check.yml and main-release.yml

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,8 +1,9 @@
-name: CI
+name: Build Check
 
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Main Release
 
 on:
   push:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,8 @@ jonathanperis.github.io/
 ├── tsconfig.json               # strict, ES2017, @/* alias
 ├── postcss.config.mjs          # Tailwind CSS v4
 └── .github/workflows/
-    ├── ci.yml                  # PR build check (lint + build)
-    ├── deploy.yml              # GitHub Pages deploy on push to main
+    ├── build-check.yml                  # PR build check (lint + build)
+    ├── main-release.yml              # GitHub Pages deploy on push to main
     └── codeql.yml              # Security analysis (JS/TS)
 ```
 
@@ -111,8 +111,8 @@ jonathanperis.github.io/
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `ci.yml` | Pull requests to main | Lint + build validation |
-| `deploy.yml` | Push to main / manual dispatch | Build → upload → deploy to GitHub Pages |
+| `build-check.yml` | Pull requests to main | Lint + build validation |
+| `main-release.yml` | Push to main / manual dispatch | Build → upload → deploy to GitHub Pages |
 | `codeql.yml` | Push, PRs, weekly (Mon 06:00 UTC) | JavaScript/TypeScript security scanning |
 
 - **Dependabot:** Weekly npm + GitHub Actions updates
@@ -130,7 +130,7 @@ jonathanperis.github.io/
 4. **Before opening a PR:** fetch and pull main again to ensure no conflicts
 5. Open a PR targeting `main` — CI runs lint + build automatically
 6. After review and green checks, rebase-merge the PR
-7. `deploy.yml` triggers automatically on push to main
+7. `main-release.yml` triggers automatically on push to main
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Personal developer portfolio built with Next.js — dynamically fetches GitHub projects, dark terminal aesthetic, print-optimized resume
 
-[![CI](https://github.com/jonathanperis/jonathanperis.github.io/actions/workflows/ci.yml/badge.svg)](https://github.com/jonathanperis/jonathanperis.github.io/actions/workflows/ci.yml) [![Deploy to GitHub Pages](https://github.com/jonathanperis/jonathanperis.github.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/jonathanperis/jonathanperis.github.io/actions/workflows/deploy.yml) [![CodeQL](https://github.com/jonathanperis/jonathanperis.github.io/actions/workflows/codeql.yml/badge.svg)](https://github.com/jonathanperis/jonathanperis.github.io/actions/workflows/codeql.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Build Check](https://github.com/jonathanperis/jonathanperis.github.io/actions/workflows/build-check.yml/badge.svg)](https://github.com/jonathanperis/jonathanperis.github.io/actions/workflows/build-check.yml) [![Main Release](https://github.com/jonathanperis/jonathanperis.github.io/actions/workflows/main-release.yml/badge.svg)](https://github.com/jonathanperis/jonathanperis.github.io/actions/workflows/main-release.yml) [![CodeQL](https://github.com/jonathanperis/jonathanperis.github.io/actions/workflows/codeql.yml/badge.svg)](https://github.com/jonathanperis/jonathanperis.github.io/actions/workflows/codeql.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 **[Live demo →](https://jonathanperis.github.io/)** | **[Documentation →](CLAUDE.md)**
 
@@ -57,8 +57,8 @@ Open http://localhost:3000
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `ci.yml` | Pull requests to main | Lint + build check |
-| `deploy.yml` | Push to main / manual | Build and deploy to GitHub Pages |
+| `build-check.yml` | Pull requests to main | Lint + build check |
+| `main-release.yml` | Push to main / manual | Build and deploy to GitHub Pages |
 | `codeql.yml` | Push, PRs, weekly schedule | JavaScript/TypeScript security analysis |
 
 Dependabot monitors npm and GitHub Actions dependencies weekly.


### PR DESCRIPTION
## Summary
- Renames `ci.yml` → `build-check.yml` and `deploy.yml` → `main-release.yml` to match the standard naming across all other repos
- Updates README badges to reference new workflow filenames
- Updates CLAUDE.md references accordingly

## Test plan
- [ ] Build Check workflow triggers on this PR
- [ ] Verify README badges render correctly after merge
- [ ] Main Release workflow triggers on push to main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)