### PR TITLE
fix: restore footer line spacing above social icons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -326,6 +326,6 @@ body::after {
 .footer-line {
   height: 1px;
   background: linear-gradient(90deg, transparent 0%, var(--color-violet) 30%, var(--color-violet-light) 60%, transparent 100%);
-  margin-bottom: 0;
   opacity: 0.4;
+  margin-bottom: 2rem;
 }


### PR DESCRIPTION
## Summary
- `.footer-line` had an explicit `margin-bottom: 0` that overrode Tailwind's `mb-8` utility due to CSS layer specificity (unlayered styles beat `@layer utilities`)
- Replaced with `margin-bottom: 2rem` directly in the CSS rule so spacing is reliably applied

## Test plan
- [ ] Footer gradient line appears as a separator above the social icons with proper spacing
- [ ] No visual regression on the rest of the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)