### PR TITLE
fix(ci): add Node.js 22 — Astro 5 requires >=22.12.0

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -22,6 +22,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest


### PR DESCRIPTION
## Summary
- Add `actions/setup-node@v4` (Node 22) to `build-check.yml` and `main-release.yml`
- Astro 5 hard-errors on Node < 22.12.0; GH runner default is Node 20.20.2

## Root Cause
After the Next.js → Astro 5 migration, CI started failing with:
```
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```
The `oven-sh/setup-bun` action installs Bun but does not upgrade the system Node.js. Astro's build CLI detects and rejects the runner-default Node 20.

## Fix
Add `actions/setup-node@v4` with `node-version: '22'` before the Bun setup step in both workflows.

## Test plan
- [ ] Build Check passes on this PR
- [ ] Merge triggers Main Release → site deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)