### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default code owner for all files in this repository.
+# Any change requires review from @jonathanperis.
+*       @jonathanperis


### PR DESCRIPTION
## Summary
- Adds `CODEOWNERS` at repo root with `@jonathanperis` as default reviewer

## Context
Part of an org-wide rollout. CODEOWNERS does **not** cascade from `jonathanperis/.github` like SECURITY.md / CONTRIBUTING.md do — each repo needs its own copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)