### PR TITLE
docs: migrate wiki content to wiki/ folder

### DIFF
--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -1,0 +1,44 @@
+# Architecture
+
+## Overview
+
+The site is a **Next.js 16** static export deployed to **GitHub Pages**. It uses a Server Component / Client Component split to fetch data at build time while keeping all interactive UI client-side.
+
+## Component Architecture
+
+```
+app/
+├── page.tsx              # Server Component — fetches pinned repos
+├── portfolio.tsx          # Client Component — full interactive UI
+├── resume/
+│   ├── page.tsx           # Client Component — print-optimized resume
+│   └── layout.tsx         # Server Component — resume metadata
+├── lib/
+│   ├── data.ts            # Shared data (single source of truth)
+│   └── github.ts          # GitHub GraphQL API client
+├── components/
+│   ├── analytics.tsx      # Google Analytics 4
+│   └── json-ld.tsx        # Schema.org structured data
+├── layout.tsx             # Root layout, metadata, fonts, SEO
+└── globals.css            # Theme, animations, styles
+```
+
+## Data Flow
+
+```
+Build Time:
+  page.tsx (Server) → github.ts → GitHub GraphQL API
+                    → fetches pinned repos
+                    → passes to portfolio.tsx as props
+
+Runtime (Static HTML):
+  portfolio.tsx (Client) → renders UI with baked-in data
+                         → typing animation, scroll effects, terminal
+```
+
+## Key Design Decisions
+
+- **Server/Client split** — Data fetching happens at build time (Server Component), UI interactions are client-side
+- **Single source of truth** — `lib/data.ts` contains all profile data shared between portfolio and resume
+- **Static export** — `output: "export"` in next.config.ts generates pure static HTML for GitHub Pages
+- **Graceful fallback** — If `GITHUB_TOKEN` is missing, hardcoded project data is used

--- a/wiki/deployment.md
+++ b/wiki/deployment.md
@@ -1,0 +1,56 @@
+# Deployment
+
+## GitHub Actions
+
+The site deploys automatically via `.github/workflows/deploy.yml` on every push to `master`.
+
+### Pipeline Steps
+
+1. **Checkout** — Clone the repository
+2. **Setup Node** — Node.js 20 with npm cache
+3. **Setup Pages** — Configure GitHub Pages
+4. **Install** — `npm ci`
+5. **Build** — `npm run build` with environment variables:
+   - `GITHUB_TOKEN` — Fetches pinned repos (auto-provided by GitHub Actions)
+   - `NEXT_PUBLIC_GA_ID` — Google Analytics measurement ID
+6. **Upload** — Uploads `out/` directory as Pages artifact
+7. **Deploy** — Deploys to GitHub Pages
+
+### Environment Variables
+
+| Variable | Source | Purpose |
+|---|---|---|
+| `GITHUB_TOKEN` | `secrets.GITHUB_TOKEN` (auto) | GitHub GraphQL API for pinned repos |
+| `NEXT_PUBLIC_GA_ID` | Hardcoded in workflow | GA4 measurement ID |
+
+## Static Export
+
+Next.js is configured with `output: "export"` which generates pure static HTML/CSS/JS in the `out/` directory. No server required.
+
+## Cache Headers
+
+`next.config.ts` defines aggressive caching for static assets:
+
+```typescript
+headers: async () => [
+  {
+    source: "/:all*(svg|jpg|jpeg|png|gif|ico|webp|woff|woff2)",
+    headers: [
+      { key: "Cache-Control", value: "public, max-age=31536000, immutable" },
+    ],
+  },
+]
+```
+
+## Manual Deploy
+
+To deploy manually:
+
+```bash
+GITHUB_TOKEN=$(gh auth token) NEXT_PUBLIC_GA_ID=G-GFK73008MT npm run build
+# Then push the out/ directory to GitHub Pages
+```
+
+## Domain
+
+The site is served at `https://jonathanperis.github.io` via GitHub Pages with automatic HTTPS.

--- a/wiki/dynamic_projects.md
+++ b/wiki/dynamic_projects.md
@@ -1,0 +1,57 @@
+# Dynamic Projects
+
+## How It Works
+
+The projects section is **not hardcoded** — it fetches your **pinned repositories** from GitHub at build time using the GraphQL API.
+
+## Data Flow
+
+1. `page.tsx` (Server Component) calls `fetchPinnedRepos()` from `lib/github.ts`
+2. `github.ts` sends a GraphQL query to the GitHub API:
+
+```graphql
+{
+  user(login: "jonathanperis") {
+    pinnedItems(first: 6, types: REPOSITORY) {
+      nodes {
+        ... on Repository {
+          name
+          description
+          url
+          stargazerCount
+          primaryLanguage { name color }
+        }
+      }
+    }
+  }
+}
+```
+
+3. The response is mapped to `PinnedRepo[]` and passed to `portfolio.tsx` as a prop
+4. At build time, this data is baked into the static HTML
+
+## Filtering
+
+- `jonathanperis.github.io` (this repo) is automatically excluded from the list
+- Only pinned repos are shown — pin/unpin repos on GitHub to control what appears
+
+## Play URLs
+
+Some projects have a "Play in browser" button. This is configured in `github.ts`:
+
+```typescript
+const PLAY_URLS: Record<string, string> = {
+  "super-mango-game": "https://jonathanperis.github.io/super-mango-game/",
+};
+```
+
+## Fallback
+
+If `GITHUB_TOKEN` is not available (e.g., local dev without it), hardcoded fallback data is used so the site always builds.
+
+## Updating Projects
+
+To update the projects on the live site:
+1. Pin/unpin repos on your GitHub profile
+2. Push any change to trigger a deploy
+3. The build fetches fresh data from GitHub

--- a/wiki/easter_egg.md
+++ b/wiki/easter_egg.md
@@ -1,0 +1,58 @@
+# Easter Egg
+
+## Konami Code Terminal
+
+The site includes a hidden interactive terminal triggered by the **Konami code**.
+
+### How to Activate
+
+Press these keys in sequence anywhere on the page:
+
+```
+↑ ↑ ↓ ↓ ← → ← → B A
+```
+
+### Terminal Features
+
+- macOS-style window with traffic light buttons
+- Command history (arrow up/down)
+- Ctrl+L to clear
+- Escape or red button to close
+- Click outside to dismiss
+
+### Available Commands
+
+| Command | Description |
+|---|---|
+| `help` | List all commands |
+| `about` | Bio and Seu Madruga quote |
+| `skills` | Tech stack overview |
+| `contact` | Social links and email |
+| `neofetch` | ASCII art "JP" logo with system info |
+| `git log` | Career history as commits |
+| `ls` | List sections |
+| `cat about.txt` | Read about section |
+| `whoami` | Current user info |
+| `pwd` | Current directory |
+| `date` | Current date/time |
+| `sudo hire me` | Fake auth flow |
+| `rm -rf /` | Plot armor response |
+| `cat .easter-egg` | Hidden file |
+| `echo <text>` | Echo text back |
+| `clear` | Clear terminal |
+| `exit` | Close terminal |
+
+### Hint
+
+The footer contains a subtle hint:
+
+```
+// ↑↑↓↓←→←→BA
+```
+
+### Implementation
+
+- Konami code listener in a `useEffect` hook
+- Tracks last 10 keystrokes and matches against the sequence
+- Terminal state managed with `useState` (history, input, command history)
+- `handleTerminalCommand()` function maps commands to responses

--- a/wiki/getting_started.md
+++ b/wiki/getting_started.md
@@ -1,0 +1,58 @@
+# Getting Started
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) v20 or later
+- [npm](https://www.npmjs.com/)
+- [GitHub CLI](https://cli.github.com/) (`gh`) — for local development with dynamic projects
+
+## Installation
+
+```bash
+git clone https://github.com/jonathanperis/jonathanperis.github.io.git
+cd jonathanperis.github.io
+npm install
+```
+
+## Development
+
+### Without dynamic projects (fallback data)
+
+```bash
+npm run dev
+```
+
+### With dynamic projects (live GitHub data)
+
+```bash
+GITHUB_TOKEN=$(gh auth token) npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+## Build
+
+```bash
+npm run build
+```
+
+Produces a static export in the `out/` directory.
+
+### With dynamic projects
+
+```bash
+GITHUB_TOKEN=$(gh auth token) npm run build
+```
+
+## Lint
+
+```bash
+npm run lint
+```
+
+## Environment Variables
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `GITHUB_TOKEN` | No (has fallback) | Fetches pinned repos via GraphQL at build time |
+| `NEXT_PUBLIC_GA_ID` | No | Google Analytics 4 measurement ID |

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,0 +1,27 @@
+# jonathanperis.github.io
+
+Personal developer portfolio for **Jonathan Peris** — Software Engineer with 12+ years of experience in .NET and Fintech.
+
+**Live site:** [jonathanperis.github.io](https://jonathanperis.github.io)
+
+## Features
+
+- Developer-themed dark UI with terminal aesthetic
+- Typing role animation, scroll animations, progress bar
+- Dynamic GitHub pinned repos fetched at build time via GraphQL API
+- Print-optimized resume page generated from shared data (`/resume`)
+- Interactive terminal easter egg (Konami code)
+- SEO optimized: JSON-LD, sitemap, robots.txt, Open Graph, Twitter cards
+- Google Analytics 4 integration
+- PWA-ready with manifest and icons
+
+## Wiki Pages
+
+- [Architecture](architecture)
+- [Getting Started](getting_started)
+- [Project Structure](project_structure)
+- [Dynamic Projects](dynamic_projects)
+- [Resume Page](resume_page)
+- [SEO & Analytics](seo_and_analytics)
+- [Easter Egg](easter_egg)
+- [Deployment](deployment)

--- a/wiki/project_structure.md
+++ b/wiki/project_structure.md
@@ -1,0 +1,40 @@
+# Project Structure
+
+```
+jonathanperis.github.io/
+├── app/
+│   ├── page.tsx                 # Server Component — fetches pinned repos, renders Portfolio
+│   ├── portfolio.tsx            # Client Component — main UI (hero, about, experience, projects)
+│   ├── layout.tsx               # Root layout: metadata, fonts, SEO, analytics, JSON-LD
+│   ├── globals.css              # Theme colors, animations, card/tag/timeline styles
+│   ├── resume/
+│   │   ├── page.tsx             # Print-optimized resume (shared data from lib/data.ts)
+│   │   └── layout.tsx           # Resume page metadata
+│   ├── lib/
+│   │   ├── data.ts              # Single source of truth: profile, experiences, skills, education
+│   │   └── github.ts            # GitHub GraphQL client: fetches pinned repos at build time
+│   └── components/
+│       ├── analytics.tsx        # GA4 conditional loader (reads NEXT_PUBLIC_GA_ID)
+│       └── json-ld.tsx          # Schema.org Person structured data
+├── public/
+│   ├── sitemap.xml              # Sitemap for search engines
+│   ├── robots.txt               # Crawler directives
+│   ├── manifest.json            # PWA manifest
+│   ├── favicon.svg              # SVG favicon (JP monogram)
+│   └── apple-touch-icon.png     # iOS icon
+├── .github/workflows/
+│   └── deploy.yml               # GitHub Actions: build → GitHub Pages
+├── next.config.ts               # Static export, cache headers
+├── tsconfig.json
+└── package.json
+```
+
+## Key Files
+
+| File | Role |
+|---|---|
+| `lib/data.ts` | All profile data — experiences, skills, education, socials. Shared by portfolio and resume. |
+| `lib/github.ts` | Fetches pinned repos via GitHub GraphQL API. Falls back to hardcoded data if no token. |
+| `portfolio.tsx` | The entire interactive UI — hero, typing animation, about, experience timeline, project cards, terminal easter egg. |
+| `resume/page.tsx` | Print-optimized resume. "Download PDF" button triggers browser print dialog. |
+| `globals.css` | Custom theme tokens, dot grid, scroll progress, cursor blink, git timeline, glass cards, terminal overlay. |

--- a/wiki/resume_page.md
+++ b/wiki/resume_page.md
@@ -1,0 +1,40 @@
+# Resume Page
+
+## Overview
+
+The `/resume` route renders a **print-optimized resume** from the same data that powers the portfolio. No static PDF needed — the resume is always up to date.
+
+## How It Works
+
+- `resume/page.tsx` imports from `lib/data.ts` (the single source of truth)
+- Renders: Header, Summary, Technical Skills, Experience (all 10 roles), Education
+- "Download PDF" button calls `window.print()` — the browser's print dialog saves as PDF
+
+## Sections
+
+| Section | Data Source |
+|---|---|
+| Header | `PROFILE.name`, `PROFILE.email`, `PROFILE.location`, etc. |
+| Summary | `PROFILE.summary` |
+| Technical Skills | `SKILLS` (languages, backend, architecture, cloud, databases, frontend) |
+| Experience | `EXPERIENCES[]` (10 entries with title, company, location, description, tags) |
+| Education | `EDUCATION` (BTech from UNIESP) |
+
+## Print Styling
+
+The page has dual styles:
+- **Screen**: Dark theme matching the portfolio
+- **Print**: White background, black text, proper margins, `break-inside-avoid` on experience entries
+
+```css
+@media print {
+  body { background: white; color: black; }
+  .resume-page { padding: 0.4in 0.5in; }
+  @page { size: A4; margin: 0; }
+}
+```
+
+## Navigation
+
+- The "resume" button in the portfolio navbar links to `/resume`
+- The resume page has a "Back to portfolio" link

--- a/wiki/seo_and_analytics.md
+++ b/wiki/seo_and_analytics.md
@@ -1,0 +1,57 @@
+# SEO & Analytics
+
+## Structured Data (JSON-LD)
+
+`components/json-ld.tsx` generates Schema.org `Person` markup:
+
+- Name, job title, employer (Derivative Path)
+- Social links (GitHub, LinkedIn, X, Instagram, Bluesky)
+- Skills (`knowsAbout`) — 23 technologies across 6 categories
+- Education (`alumniOf`) — UNIESP
+- Email, location
+
+This helps Google display rich knowledge panels.
+
+## Meta Tags
+
+Configured in `layout.tsx`:
+
+| Tag | Value |
+|---|---|
+| `metadataBase` | `https://jonathanperis.github.io` |
+| `canonical` | `/` |
+| `keywords` | 12 relevant terms |
+| `og:title` | Jonathan Peris — Software Engineer |
+| `og:image` | profile-image-sharing.jpeg |
+| `twitter:card` | summary_large_image |
+| `twitter:creator` | @jperis_silva |
+| `theme-color` | #09090b |
+| `hreflang` | en |
+
+## Sitemap
+
+`public/sitemap.xml` includes:
+- `/` (priority 1.0, weekly)
+- `/resume` (priority 0.8, monthly)
+
+## robots.txt
+
+```
+User-agent: *
+Allow: /
+Sitemap: https://jonathanperis.github.io/sitemap.xml
+```
+
+## Google Analytics 4
+
+`components/analytics.tsx` loads GA4 conditionally:
+- Only activates when `NEXT_PUBLIC_GA_ID` env var is set
+- Measurement ID: `G-GFK73008MT`
+- Loaded with `afterInteractive` strategy (non-blocking)
+
+## PWA Manifest
+
+`public/manifest.json` with:
+- App name, short name (JP)
+- Theme color (#4ade80), background (#09090b)
+- SVG favicon + apple-touch-icon


### PR DESCRIPTION
Migrate GitHub wiki markdown files to `wiki/` folder in main repo. Wiki will be disabled after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * New wiki documentation suite with nine pages: getting started guide for developers, architecture overview, project structure reference, deployment workflow, dynamic projects system guide, resume page documentation, SEO and analytics setup, easter egg feature guide, and navigation index for all wiki pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->