### PR TITLE
feat: explore developer-ish portfolio aesthetic

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,258 @@
+---
+version: alpha
+name: Jonathan Peris Developer Portfolio
+description: "Systems-console portfolio for a senior backend engineer: precise, dark, operational, and proof-oriented."
+colors:
+  primary: "#4ADE80"
+  background: "#08120D"
+  surface: "#101C15"
+  elevated: "#17271D"
+  border: "#294333"
+  border-strong: "#3B604A"
+  text: "#EEF8F0"
+  muted: "#B2C8B9"
+  dim: "#758B7C"
+  accent: "#4ADE80"
+  accent-light: "#86EFAC"
+  accent-dim: "#22C55E"
+  cyan: "#22D3EE"
+  purple: "#C084FC"
+  amber: "#F59E0B"
+  rose: "#FB7185"
+typography:
+  display:
+    fontFamily: DM Sans
+    fontSize: 4rem
+    fontWeight: 800
+    lineHeight: 1
+    letterSpacing: "-0.06em"
+  h1:
+    fontFamily: DM Sans
+    fontSize: 3.5rem
+    fontWeight: 800
+    lineHeight: 1.05
+    letterSpacing: "-0.05em"
+  h2:
+    fontFamily: DM Sans
+    fontSize: 2rem
+    fontWeight: 750
+    lineHeight: 1.1
+    letterSpacing: "-0.04em"
+  body:
+    fontFamily: DM Sans
+    fontSize: 1rem
+    fontWeight: 400
+    lineHeight: 1.65
+    letterSpacing: "0em"
+  small-mono:
+    fontFamily: JetBrains Mono
+    fontSize: 0.75rem
+    fontWeight: 600
+    lineHeight: 1.4
+    letterSpacing: "0.08em"
+rounded:
+  sm: 6px
+  md: 12px
+  lg: 18px
+  xl: 28px
+spacing:
+  xs: 4px
+  sm: 8px
+  md: 16px
+  lg: 24px
+  xl: 40px
+  xxl: 64px
+components:
+  page:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.muted}"
+  card:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.text}"
+    rounded: "{rounded.md}"
+    padding: 24px
+  card-hover:
+    backgroundColor: "{colors.elevated}"
+    textColor: "{colors.text}"
+    rounded: "{rounded.md}"
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.background}"
+    rounded: "{rounded.sm}"
+    padding: 12px
+  button-secondary:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.accent-light}"
+    rounded: "{rounded.sm}"
+    padding: 12px
+  button-secondary-hover:
+    backgroundColor: "{colors.elevated}"
+    textColor: "{colors.accent}"
+    rounded: "{rounded.sm}"
+    padding: 12px
+  chip:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.accent-light}"
+    rounded: "{rounded.sm}"
+    padding: 8px
+  chip-muted:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.dim}"
+    rounded: "{rounded.sm}"
+    padding: 8px
+  card-outline:
+    backgroundColor: "{colors.border}"
+    textColor: "{colors.text}"
+    rounded: "{rounded.md}"
+    padding: 16px
+  card-outline-hover:
+    backgroundColor: "{colors.border-strong}"
+    textColor: "{colors.text}"
+    rounded: "{rounded.md}"
+    padding: 16px
+  terminal:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.text}"
+    rounded: "{rounded.lg}"
+    padding: 16px
+  terminal-prompt:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.accent-dim}"
+    rounded: "{rounded.sm}"
+    padding: 4px
+  tag-cyan:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.cyan}"
+    rounded: "{rounded.sm}"
+    padding: 8px
+  tag-purple:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.purple}"
+    rounded: "{rounded.sm}"
+    padding: 8px
+  tag-amber:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.amber}"
+    rounded: "{rounded.sm}"
+    padding: 8px
+  tag-rose:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.rose}"
+    rounded: "{rounded.sm}"
+    padding: 8px
+---
+
+## Overview
+
+This design system supports `PRODUCT.md`: a proof-oriented portfolio for Jonathan Peris, a senior backend/platform engineer. The interface should feel like an operating console, deployment ledger, trace viewer, or systems manual — not like a generic portfolio template.
+
+The visual mood is dark green-black, precise, calm, and technical. It should communicate engineering maturity: clear hierarchy, restrained motion, strong text contrast, and small operational details that reward technical visitors without slowing down recruiters.
+
+The strongest design idea is **developer-ish but not gimmicky**: routes, manifests, chips, ledgers, traces, shell affordances, and repository cards are welcome; fake danger, hacker-roleplay, neon overload, and illegible cyberpunk effects are not.
+
+## Colors
+
+- **Background (`#08120D`)** anchors the site in a dark operational workspace.
+- **Surface (`#101C15`)** and **elevated (`#17271D`)** separate cards, panels, and terminal areas without bright boxes.
+- **Text (`#EEF8F0`)** is used for important copy and headings.
+- **Muted (`#B2C8B9`)** is the default long-form reading color.
+- **Dim (`#758B7C`)** is reserved for metadata, timestamps, route labels, and secondary captions.
+- **Accent (`#4ADE80`)** is the primary interaction and status color. It implies healthy systems, deploy readiness, and availability.
+- **Accent light (`#86EFAC`)** can highlight hover states, active labels, and emphasized links.
+- **Cyan, purple, amber, and rose** are supporting syntax/status colors. Use sparingly for language dots, stack tags, or code-like semantics.
+
+Use the accent color as a precision instrument, not a flood fill. Large panels should stay dark; green should mark state, focus, and the most important calls to action.
+
+## Typography
+
+Use **DM Sans** for both display and body text. The brand should feel modern, legible, and engineered rather than editorial or ornamental.
+
+Use **JetBrains Mono** for:
+
+- route-style labels (`/profile`, `/trace`, `/workbench`),
+- metadata and timestamps,
+- shell content,
+- manifest/YAML snippets,
+- small tags and status chips.
+
+Large headings should be compact and assertive, with tight negative tracking. Avoid decorative serif display type for this version; the product direction is operational clarity, not magazine polish.
+
+## Layout
+
+The layout should read like a technical dossier:
+
+1. **Hero / command surface:** immediate name, availability, role, remote context, resume/contact CTAs, and a manifest-like proof panel.
+2. **Profile packet:** concise summary of Jonathan's value proposition and operating principles.
+3. **Capability map:** stack grouped by language, backend, architecture, cloud, data, and frontend.
+4. **Experience trace:** chronological production history with the current role visually elevated.
+5. **Workbench:** curated featured projects before dynamic repository tail.
+6. **Repository tail and footer:** more proof, socials, and shell/easter-egg affordances.
+
+Spacing should be generous enough to feel calm, but dense enough to preserve a systems-console rhythm. Prefer grids, ledgers, and cards over large decorative illustrations.
+
+## Elevation & Depth
+
+Depth is subtle and mostly structural:
+
+- 1px borders for cards and panels.
+- Low-opacity green glows only on hero atmosphere, active states, and hover emphasis.
+- Noise/dot overlays may add texture, but must stay quiet and never reduce text readability.
+- Avoid glassmorphism that makes text sit on unstable backgrounds.
+
+Hover states can lift a card with a stronger border and shadow, but the base page should remain still and professional.
+
+## Shapes
+
+Use mostly rectangular cards with modest rounding:
+
+- `6px` for chips, buttons, and compact tags.
+- `12px` for cards and code panels.
+- `18px` to `28px` for large hero/terminal surfaces.
+
+Do not use pill shapes everywhere. Reserve pills for availability/status indicators and high-level signals.
+
+## Components
+
+### Navigation
+
+Navigation may use route-like labels and should stay sticky. Keep the resume/contact path visible and obvious.
+
+### Hero manifest / deploy ledger
+
+The hero proof panel may resemble YAML, a deploy ledger, or a terminal card. It should contain truthful product signals: experience, current lane, location/remote fit, availability, and key stack.
+
+### Cards
+
+Cards should be information-dense but not cramped. Each card needs a clear title, metadata, and one concise proof statement. Featured project cards can use language color accents, but the surrounding panel should remain in the main palette.
+
+### Tags and chips
+
+Tags are metadata, not decoration. Use them to make stack and domain fit scannable. Avoid turning every noun into a chip.
+
+### Terminal / shell
+
+The shell is a progressive enhancement and personality layer. It must not be the only way to access resume, contact, stack, or availability information. Keyboard behavior should be predictable: `Enter` submits, `Escape` closes, and focus is visible.
+
+### CTAs
+
+Primary CTA: resume/contact/hire path. Secondary CTA: GitHub, LinkedIn, project links, or open shell. CTAs should use clear verbs and preserve native link behavior.
+
+## Do's and Don'ts
+
+### Do
+
+- Make seniority, .NET/backend depth, remote readiness, and availability visible immediately.
+- Use operational metaphors: traces, manifests, ledgers, workbench, status, signals.
+- Keep claims tied to proof: current role, project links, stack groups, and work history.
+- Keep contrast high and body copy readable on dark backgrounds.
+- Use CSS-first motion and respect reduced-motion preferences when adding new animation.
+- Keep frequently edited content in `src/lib/data.ts`.
+
+### Don't
+
+- Don't make the site feel like a crypto, hacker, cyberpunk, or gaming landing page.
+- Don't hide contact or resume behind easter eggs.
+- Don't overuse neon green, blur, scanlines, or fake terminal noise.
+- Don't inflate claims beyond what `PRODUCT.md`, work history, and repositories support.
+- Don't replace human clarity with clever labels; route-style copy must still be understandable.
+- Don't introduce heavy runtime dependencies for purely decorative effects.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,118 @@
+# PRODUCT.md
+
+## Product
+
+`jonathanperis.github.io` is Jonathan Peris's public developer portfolio and proof-of-work hub. It should help hiring managers, technical interviewers, engineering leaders, collaborators, and consulting prospects understand who Jonathan is, what he is strong at, and why he is credible for backend/system architecture work.
+
+The site is not a generic resume template. It is a compact technical artifact that should feel like it belongs to an engineer who builds production systems, cares about delivery, and can still make the interface memorable.
+
+## Primary Outcomes
+
+1. **Convert qualified visitors into conversations.** Make it easy for the right person to contact Jonathan for remote roles, backend/platform engineering work, or selected architecture consulting.
+2. **Communicate seniority quickly.** Within the first screen, make clear: 12+ years, .NET/Azure/fintech depth, remote collaboration, and production ownership.
+3. **Show proof, not just claims.** Use work history, featured repositories, live project links, and concise engineering principles to demonstrate taste and execution.
+4. **Keep the portfolio maintainable.** The content model, components, and design tokens should be simple enough for future agents and humans to update safely.
+
+## Audience
+
+### Hiring managers and recruiters
+
+They need a fast answer to: "Is this person relevant for a senior software engineering role?" The page should foreground current role, availability, location/remote context, contact links, resume, and technology fit.
+
+### Engineering leaders and staff/principal engineers
+
+They need evidence of judgment. The site should emphasize systems thinking, reliability, boundaries, delivery discipline, and concrete project/work examples instead of buzzword density.
+
+### Technical interviewers
+
+They need scannable signals: stack, past domains, architecture vocabulary, repository links, and enough implementation detail to start a deeper technical conversation.
+
+### Consulting prospects and collaborators
+
+They need to know where Jonathan can help: backend architecture, .NET modernization, fintech/business systems, cloud delivery, and pragmatic implementation.
+
+## Positioning
+
+Jonathan is a production-focused software engineer with 12+ years of experience, centered on .NET, fintech/business systems, cloud delivery, and clean architecture. The strongest positioning is:
+
+> Senior backend/platform engineer for teams that need durable business systems, clear architecture boundaries, and reliable delivery.
+
+Supporting signals:
+
+- Current software engineering work at Derivative Path on financial modules: General Ledger, Hedge Accounting, Fiscal Calendar, and DerivativeEDGE.
+- Deep .NET ecosystem experience: .NET Core+, ASP.NET Core, Entity Framework, MAUI, Blazor.
+- Architecture vocabulary backed by years of delivery: CQRS, DDD, microservices, hexagonal architecture, clean architecture, SAGA pattern.
+- DevOps/cloud literacy: Azure, Azure DevOps, Docker, Kubernetes, CI/CD.
+- Curiosity beyond the main lane: Rust, Go, Python, TypeScript, WebAssembly, game/dev experiments, and performance-oriented repositories.
+
+## Brand Personality
+
+- **Competent, not loud.** Confident language, restrained claims, proof-first framing.
+- **Systems-minded.** The interface may borrow from terminals, runbooks, traces, manifests, and deployment ledgers.
+- **Human but concise.** Keep small personal touches and easter eggs, but do not let them obscure professional clarity.
+- **Pragmatic.** Architecture is framed as a way to reduce operational cost, not as decoration.
+- **Remote-ready.** Brazil-based, US-team-friendly, async-capable, comfortable with distributed engineering work.
+
+## Content Principles
+
+1. **Lead with the current value proposition.** The hero should quickly communicate role, experience, availability, location/remote fit, and contact path.
+2. **Every section earns its space.** Avoid filler sections; each block should answer a likely visitor question.
+3. **Prefer specific nouns.** Use concrete domains, modules, stacks, and project names over generic adjectives.
+4. **Separate signals from proof.** A short signal chip can say ".NET + Azure"; a nearby section should explain where that shows up in work.
+5. **Keep availability current.** The current stance is: open to remote roles and selected backend architecture consulting.
+6. **Keep generated repository data subordinate.** Dynamic GitHub projects are useful proof, but the curated workbench/featured list should set the narrative.
+
+## Required User Journeys
+
+### Recruiter fast path
+
+1. Land on homepage.
+2. See availability, role, experience, and remote/location context immediately.
+3. Click LinkedIn, email/contact, or resume without scrolling deeply.
+
+### Engineering evaluator path
+
+1. Read hero and profile packet.
+2. Scan capability map and engineering principles.
+3. Inspect experience trace and featured projects.
+4. Open GitHub/live project links.
+
+### Curious developer path
+
+1. Notice the console/runbook aesthetic.
+2. Open the interactive shell or find the easter egg.
+3. Explore repositories and social links.
+
+## Functional Requirements
+
+- Static Astro site deployable to GitHub Pages.
+- React-powered interactive portfolio component.
+- Build-time GitHub project fetching where configured, with safe fallbacks.
+- Resume route and/or resume CTA available from primary navigation.
+- Contact/social links available in hero/footer and keyboard/screen-reader accessible.
+- Hidden shell/easter egg preserved as progressive enhancement; core content must remain useful without it.
+- Analytics events may track outbound/social/resume interactions, but must not block navigation.
+
+## Non-Goals
+
+- Do not become a blog platform unless there is an explicit content strategy.
+- Do not over-index on animation at the expense of readability or performance.
+- Do not present Jonathan as a full-service agency or generic freelancer marketplace profile.
+- Do not hide the resume/contact path behind clever terminal interactions.
+- Do not let the site look like a cryptocurrency, cyberpunk, gaming, or hacker-roleplay landing page.
+
+## Product Quality Bar
+
+- **Clarity:** A first-time visitor should understand Jonathan's profile in under 10 seconds.
+- **Credibility:** Claims should map to work history, project links, or explicit engineering principles.
+- **Accessibility:** Text contrast, focus states, semantic structure, and reduced-motion friendliness matter.
+- **Performance:** Static output should remain lightweight; decorative effects should be CSS-first.
+- **Maintainability:** Data that changes often belongs in `src/lib/data.ts`; global visual decisions belong in `DESIGN.md` and CSS tokens.
+- **Trust:** External links should be accurate, current, and safe (`rel="noreferrer noopener"`).
+
+## Success Signals
+
+- More qualified inbound contact via LinkedIn/email/Workana/GitHub.
+- Recruiters can quickly identify Jonathan as a senior .NET/backend engineer.
+- Technical reviewers can cite specific projects, architecture choices, and domains.
+- Future redesigns remain consistent because `PRODUCT.md` defines product intent and `DESIGN.md` defines visual rules.

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -11,6 +11,6 @@ export default defineConfig({
     sitemap(),
   ],
   vite: {
-    plugins: [tailwindcss()],
+    plugins: [tailwindcss() as never],
   },
 });

--- a/bun.lock
+++ b/bun.lock
@@ -5,35 +5,42 @@
     "": {
       "name": "jonathanperis.github.io",
       "dependencies": {
-        "@astrojs/react": "^4",
+        "@astrojs/react": "^5",
         "@astrojs/sitemap": "^3",
-        "astro": "^5",
+        "astro": "^6",
         "react": "^19",
         "react-dom": "^19",
       },
       "devDependencies": {
+        "@astrojs/check": "^0.9.9",
         "@tailwindcss/vite": "^4",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "tailwindcss": "^4",
-        "typescript": "^5",
+        "typescript": "^6",
       },
     },
   },
   "packages": {
-    "@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
+    "@astrojs/check": ["@astrojs/check@0.9.9", "", { "dependencies": { "@astrojs/language-server": "^2.16.7", "chokidar": "^4.0.3", "kleur": "^4.1.5", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0" }, "bin": { "astro-check": "bin/astro-check.js" } }, "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg=="],
 
-    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.7.6", "", {}, "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q=="],
+    "@astrojs/compiler": ["@astrojs/compiler@4.0.0", "", {}, "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA=="],
 
-    "@astrojs/markdown-remark": ["@astrojs/markdown-remark@6.3.11", "", { "dependencies": { "@astrojs/internal-helpers": "0.7.6", "@astrojs/prism": "3.3.0", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "import-meta-resolve": "^4.2.0", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "shiki": "^3.21.0", "smol-toml": "^1.6.0", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ=="],
+    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.9.1", "", { "dependencies": { "picomatch": "^4.0.4" } }, "sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ=="],
 
-    "@astrojs/prism": ["@astrojs/prism@3.3.0", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ=="],
+    "@astrojs/language-server": ["@astrojs/language-server@2.16.8", "", { "dependencies": { "@astrojs/compiler": "^2.13.1", "@astrojs/yaml2ts": "^0.2.3", "@jridgewell/sourcemap-codec": "^1.5.5", "@volar/kit": "~2.4.28", "@volar/language-core": "~2.4.28", "@volar/language-server": "~2.4.28", "@volar/language-service": "~2.4.28", "muggle-string": "^0.4.1", "tinyglobby": "^0.2.16", "volar-service-css": "0.0.70", "volar-service-emmet": "0.0.70", "volar-service-html": "0.0.70", "volar-service-prettier": "0.0.70", "volar-service-typescript": "0.0.70", "volar-service-typescript-twoslash-queries": "0.0.70", "volar-service-yaml": "0.0.70", "vscode-html-languageservice": "^5.6.2", "vscode-uri": "^3.1.0" }, "peerDependencies": { "prettier": "^3.0.0", "prettier-plugin-astro": ">=0.11.0" }, "optionalPeers": ["prettier", "prettier-plugin-astro"], "bin": { "astro-ls": "bin/nodeServer.js" } }, "sha512-yg1pZF6hs9FaKr2fgXMOGbW7pDLgFexFjuhWilPAc8VybTU+WSnbfbhYaUL1exm6dAK4sM3aKXGcfVwss+HXbg=="],
 
-    "@astrojs/react": ["@astrojs/react@4.4.2", "", { "dependencies": { "@vitejs/plugin-react": "^4.7.0", "ultrahtml": "^1.6.0", "vite": "^6.4.1" }, "peerDependencies": { "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0", "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0" } }, "sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ=="],
+    "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.1.2", "", { "dependencies": { "@astrojs/internal-helpers": "0.9.1", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "retext-smartypants": "^6.2.0", "shiki": "^4.0.0", "smol-toml": "^1.6.0", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q=="],
+
+    "@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
+
+    "@astrojs/react": ["@astrojs/react@5.0.5", "", { "dependencies": { "@astrojs/internal-helpers": "0.9.1", "@vitejs/plugin-react": "^5.2.0", "devalue": "^5.6.4", "ultrahtml": "^1.6.0", "vite": "^7.3.2" }, "peerDependencies": { "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0", "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0" } }, "sha512-5jSFDqWqLdEyp7CEVD66A7AQEEuwLkCGR25NJ4FR5EjziZQqZTGc7hJOFZ97qb98BiU6vElrS70R8iI+HhufGQ=="],
 
     "@astrojs/sitemap": ["@astrojs/sitemap@3.7.2", "", { "dependencies": { "sitemap": "^9.0.0", "stream-replace-string": "^2.0.0", "zod": "^4.3.6" } }, "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA=="],
 
-    "@astrojs/telemetry": ["@astrojs/telemetry@3.3.0", "", { "dependencies": { "ci-info": "^4.2.0", "debug": "^4.4.0", "dlv": "^1.1.3", "dset": "^3.1.4", "is-docker": "^3.0.0", "is-wsl": "^3.1.0", "which-pm-runs": "^1.1.0" } }, "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ=="],
+    "@astrojs/telemetry": ["@astrojs/telemetry@3.3.2", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "is-wsl": "^3.1.1", "which-pm-runs": "^1.1.0" } }, "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ=="],
+
+    "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.3", "", { "dependencies": { "yaml": "^2.8.2" } }, "sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -74,6 +81,24 @@
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
+
+    "@clack/core": ["@clack/core@1.3.1", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA=="],
+
+    "@clack/prompts": ["@clack/prompts@1.4.0", "", { "dependencies": { "@clack/core": "1.3.1", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA=="],
+
+    "@emmetio/abbreviation": ["@emmetio/abbreviation@2.3.3", "", { "dependencies": { "@emmetio/scanner": "^1.0.4" } }, "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA=="],
+
+    "@emmetio/css-abbreviation": ["@emmetio/css-abbreviation@2.1.8", "", { "dependencies": { "@emmetio/scanner": "^1.0.4" } }, "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw=="],
+
+    "@emmetio/css-parser": ["@emmetio/css-parser@0.4.1", "", { "dependencies": { "@emmetio/stream-reader": "^2.2.0", "@emmetio/stream-reader-utils": "^0.1.0" } }, "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ=="],
+
+    "@emmetio/html-matcher": ["@emmetio/html-matcher@1.3.0", "", { "dependencies": { "@emmetio/scanner": "^1.0.0" } }, "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ=="],
+
+    "@emmetio/scanner": ["@emmetio/scanner@1.0.4", "", {}, "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA=="],
+
+    "@emmetio/stream-reader": ["@emmetio/stream-reader@2.2.0", "", {}, "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw=="],
+
+    "@emmetio/stream-reader-utils": ["@emmetio/stream-reader-utils@0.1.0", "", {}, "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
@@ -191,7 +216,7 @@
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
@@ -245,17 +270,19 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ=="],
 
-    "@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
+    "@shikijs/core": ["@shikijs/core@4.0.2", "", { "dependencies": { "@shikijs/primitive": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw=="],
 
-    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA=="],
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag=="],
 
-    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg=="],
 
-    "@shikijs/langs": ["@shikijs/langs@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg=="],
+    "@shikijs/langs": ["@shikijs/langs@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg=="],
 
-    "@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
+    "@shikijs/primitive": ["@shikijs/primitive@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw=="],
 
-    "@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+    "@shikijs/themes": ["@shikijs/themes@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA=="],
+
+    "@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
@@ -321,15 +348,31 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
-    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
-    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+    "@volar/kit": ["@volar/kit@2.4.28", "", { "dependencies": { "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "typesafe-path": "^0.2.2", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "typescript": "*" } }, "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg=="],
 
-    "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
+    "@volar/language-core": ["@volar/language-core@2.4.28", "", { "dependencies": { "@volar/source-map": "2.4.28" } }, "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "@volar/language-server": ["@volar/language-server@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "path-browserify": "^1.0.1", "request-light": "^0.7.0", "vscode-languageserver": "^9.0.1", "vscode-languageserver-protocol": "^3.17.5", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" } }, "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw=="],
 
-    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+    "@volar/language-service": ["@volar/language-service@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "vscode-languageserver-protocol": "^3.17.5", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" } }, "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw=="],
+
+    "@volar/source-map": ["@volar/source-map@2.4.28", "", {}, "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ=="],
+
+    "@volar/typescript": ["@volar/typescript@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "path-browserify": "^1.0.1", "vscode-uri": "^3.0.8" } }, "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw=="],
+
+    "@vscode/emmet-helper": ["@vscode/emmet-helper@2.11.0", "", { "dependencies": { "emmet": "^2.4.3", "jsonc-parser": "^2.3.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.15.1", "vscode-uri": "^3.0.8" } }, "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw=="],
+
+    "@vscode/l10n": ["@vscode/l10n@0.0.18", "", {}, "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
@@ -341,29 +384,21 @@
 
     "array-iterate": ["array-iterate@2.0.1", "", {}, "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg=="],
 
-    "astro": ["astro@5.18.1", "", { "dependencies": { "@astrojs/compiler": "^2.13.0", "@astrojs/internal-helpers": "0.7.6", "@astrojs/markdown-remark": "6.3.11", "@astrojs/telemetry": "3.3.0", "@capsizecss/unpack": "^4.0.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "acorn": "^8.15.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "boxen": "8.0.1", "ci-info": "^4.3.1", "clsx": "^2.1.1", "common-ancestor-path": "^1.0.1", "cookie": "^1.1.1", "cssesc": "^3.0.0", "debug": "^4.4.3", "deterministic-object-hash": "^2.0.2", "devalue": "^5.6.2", "diff": "^8.0.3", "dlv": "^1.1.3", "dset": "^3.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.27.3", "estree-walker": "^3.0.3", "flattie": "^1.1.1", "fontace": "~0.4.0", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "import-meta-resolve": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.1", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "p-limit": "^6.2.0", "p-queue": "^8.1.1", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.3", "prompts": "^2.4.2", "rehype": "^13.0.2", "semver": "^7.7.3", "shiki": "^3.21.0", "smol-toml": "^1.6.0", "svgo": "^4.0.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.3", "unist-util-visit": "^5.0.0", "unstorage": "^1.17.4", "vfile": "^6.0.3", "vite": "^6.4.1", "vitefu": "^1.1.1", "xxhash-wasm": "^1.1.0", "yargs-parser": "^21.1.1", "yocto-spinner": "^0.2.3", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1", "zod-to-ts": "^1.2.0" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "astro.js" } }, "sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g=="],
+    "astro": ["astro@6.3.3", "", { "dependencies": { "@astrojs/compiler": "^4.0.0", "@astrojs/internal-helpers": "0.9.1", "@astrojs/markdown-remark": "7.1.2", "@astrojs/telemetry": "3.3.2", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.6.3", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^7.3.2", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "./bin/astro.mjs" } }, "sha512-wvLIZQYbBZt6U8gyflBW4SLBypaqdwLZUH93rT3oT53cmQ0bTGubvMAGjqBRoheOYzYcTJZtW6czztzbu4kQ5g=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
-    "base-64": ["base-64@1.0.0", "", {}, "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="],
-
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.17", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
-    "boxen": ["boxen@8.0.1", "", { "dependencies": { "ansi-align": "^3.0.1", "camelcase": "^8.0.0", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "string-width": "^7.2.0", "type-fest": "^4.21.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0" } }, "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw=="],
-
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
-
-    "camelcase": ["camelcase@8.0.0", "", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001787", "", {}, "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
-
-    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
@@ -371,19 +406,23 @@
 
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
-    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
-    "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
-    "common-ancestor-path": ["common-ancestor-path@1.0.1", "", {}, "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w=="],
+    "common-ancestor-path": ["common-ancestor-path@2.0.0", "", {}, "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -398,8 +437,6 @@
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
     "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
-
-    "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "csso": ["csso@5.0.5", "", { "dependencies": { "css-tree": "~2.2.0" } }, "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="],
 
@@ -417,15 +454,11 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "deterministic-object-hash": ["deterministic-object-hash@2.0.2", "", { "dependencies": { "base-64": "^1.0.0" } }, "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ=="],
-
     "devalue": ["devalue@5.7.1", "", {}, "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
-
-    "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -439,13 +472,15 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.334", "", {}, "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog=="],
 
-    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+    "emmet": ["emmet@2.4.11", "", { "dependencies": { "@emmetio/abbreviation": "^2.3.3", "@emmetio/css-abbreviation": "^2.1.8" } }, "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
-    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
 
     "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
@@ -453,11 +488,21 @@
 
     "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
-    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -471,7 +516,9 @@
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
-    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-tsconfig": ["get-tsconfig@5.0.0-beta.4", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ=="],
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
@@ -505,11 +552,9 @@
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
-    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
-
     "iron-webcrypto": ["iron-webcrypto@1.2.1", "", {}, "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg=="],
 
-    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+    "is-docker": ["is-docker@4.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
@@ -527,9 +572,13 @@
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
-    "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -653,6 +702,8 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
+
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
@@ -669,6 +720,8 @@
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
     "ofetch": ["ofetch@1.5.1", "", { "dependencies": { "destr": "^2.0.5", "node-fetch-native": "^1.6.7", "ufo": "^1.6.1" } }, "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA=="],
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
@@ -677,17 +730,19 @@
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.5", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ=="],
 
-    "p-limit": ["p-limit@6.2.0", "", { "dependencies": { "yocto-queue": "^1.1.1" } }, "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA=="],
+    "p-limit": ["p-limit@7.3.0", "", { "dependencies": { "yocto-queue": "^1.2.1" } }, "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw=="],
 
-    "p-queue": ["p-queue@8.1.1", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^6.1.2" } }, "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ=="],
+    "p-queue": ["p-queue@9.3.0", "", { "dependencies": { "eventemitter3": "^5.0.4", "p-timeout": "^7.0.0" } }, "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang=="],
 
-    "p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
+    "p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
 
     "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
     "parse-latin": ["parse-latin@7.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "@types/unist": "^3.0.0", "nlcst-to-string": "^4.0.0", "unist-util-modify-children": "^4.0.0", "unist-util-visit-children": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ=="],
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "piccolore": ["piccolore@0.1.3", "", {}, "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw=="],
 
@@ -697,9 +752,9 @@
 
     "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
-    "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
-    "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
+    "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
@@ -709,9 +764,9 @@
 
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
-    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+    "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
-    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
@@ -737,6 +792,14 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
+    "request-light": ["request-light@0.7.0", "", {}, "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
     "retext": ["retext@9.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "retext-latin": "^4.0.0", "retext-stringify": "^4.0.0", "unified": "^11.0.0" } }, "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA=="],
 
     "retext-latin": ["retext-latin@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "parse-latin": "^7.0.0", "unified": "^11.0.0" } }, "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA=="],
@@ -755,7 +818,7 @@
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
-    "shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
+    "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
@@ -769,11 +832,11 @@
 
     "stream-replace-string": ["stream-replace-string@2.0.0", "", {}, "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="],
 
-    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
-    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "svgo": ["svgo@4.0.1", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "./bin/svgo.js" }, "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w=="],
 
@@ -783,6 +846,8 @@
 
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
+    "tinyclip": ["tinyclip@0.1.12", "", {}, "sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA=="],
+
     "tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
@@ -791,13 +856,13 @@
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
-    "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
-
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+    "typesafe-path": ["typesafe-path@0.2.2", "", {}, "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "typescript-auto-import-cache": ["typescript-auto-import-cache@0.3.6", "", { "dependencies": { "semver": "^7.3.8" } }, "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ=="],
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
@@ -843,41 +908,75 @@
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
+    "volar-service-css": ["volar-service-css@0.0.70", "", { "dependencies": { "vscode-css-languageservice": "^6.3.0", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw=="],
+
+    "volar-service-emmet": ["volar-service-emmet@0.0.70", "", { "dependencies": { "@emmetio/css-parser": "^0.4.1", "@emmetio/html-matcher": "^1.3.0", "@vscode/emmet-helper": "^2.9.3", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-xi5bC4m/VyE3zy/n2CXspKeDZs3qA41tHLTw275/7dNWM/RqE2z3BnDICQybHIVp/6G1iOQj5c1qXMgQC08TNg=="],
+
+    "volar-service-html": ["volar-service-html@0.0.70", "", { "dependencies": { "vscode-html-languageservice": "^5.3.0", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ=="],
+
+    "volar-service-prettier": ["volar-service-prettier@0.0.70", "", { "dependencies": { "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0", "prettier": "^2.2 || ^3.0" }, "optionalPeers": ["@volar/language-service", "prettier"] }, "sha512-Z6BCFSpGVCd8BPAsZ785Kce1BGlWd5ODqmqZGVuB14MJvrR4+CYz6cDy4F+igmE1gMifqfvMhdgT8Aud4M5ngg=="],
+
+    "volar-service-typescript": ["volar-service-typescript@0.0.70", "", { "dependencies": { "path-browserify": "^1.0.1", "semver": "^7.6.2", "typescript-auto-import-cache": "^0.3.5", "vscode-languageserver-textdocument": "^1.0.11", "vscode-nls": "^5.2.0", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg=="],
+
+    "volar-service-typescript-twoslash-queries": ["volar-service-typescript-twoslash-queries@0.0.70", "", { "dependencies": { "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ=="],
+
+    "volar-service-yaml": ["volar-service-yaml@0.0.70", "", { "dependencies": { "vscode-uri": "^3.0.8", "yaml-language-server": "~1.20.0" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-0c8bXDBeoATF9F6iPIlOuYTuZAC4c+yi0siQo920u7eiBJk8oQmUmg9cDUbR4+Gl++bvGP4plj3fErbJuPqdcQ=="],
+
+    "vscode-css-languageservice": ["vscode-css-languageservice@6.3.10", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "vscode-languageserver-textdocument": "^1.0.12", "vscode-languageserver-types": "3.17.5", "vscode-uri": "^3.1.0" } }, "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA=="],
+
+    "vscode-html-languageservice": ["vscode-html-languageservice@5.6.2", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "vscode-languageserver-textdocument": "^1.0.12", "vscode-languageserver-types": "^3.17.5", "vscode-uri": "^3.1.0" } }, "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg=="],
+
+    "vscode-json-languageservice": ["vscode-json-languageservice@4.1.8", "", { "dependencies": { "jsonc-parser": "^3.0.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.16.0", "vscode-nls": "^5.0.0", "vscode-uri": "^3.0.2" } }, "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg=="],
+
+    "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
+
+    "vscode-languageserver": ["vscode-languageserver@9.0.1", "", { "dependencies": { "vscode-languageserver-protocol": "3.17.5" }, "bin": { "installServerIntoExtension": "bin/installServerIntoExtension" } }, "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g=="],
+
+    "vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
+
+    "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
+
+    "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
+    "vscode-nls": ["vscode-nls@5.2.0", "", {}, "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="],
+
+    "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
+
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
 
-    "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
-
-    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "yaml-language-server": ["yaml-language-server@1.20.0", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "prettier": "^3.5.0", "request-light": "^0.5.7", "vscode-json-languageservice": "4.1.8", "vscode-languageserver": "^9.0.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.16.0", "vscode-uri": "^3.0.2", "yaml": "2.7.1" }, "bin": { "yaml-language-server": "bin/yaml-language-server" } }, "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
-    "yocto-spinner": ["yocto-spinner@0.2.3", "", { "dependencies": { "yoctocolors": "^2.1.1" } }, "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ=="],
-
-    "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
-
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
-
-    "zod-to-ts": ["zod-to-ts@1.2.0", "", { "peerDependencies": { "typescript": "^4.9.4 || ^5.0.2", "zod": "^3" } }, "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA=="],
-
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
+
+    "@astrojs/react/vite": ["vite@7.3.3", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
@@ -891,25 +990,31 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "@vscode/emmet-helper/jsonc-parser": ["jsonc-parser@2.3.1", "", {}, "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "astro/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "astro/vite": ["vite@7.3.3", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
+    "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
-    "zod-to-ts/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "yaml-language-server/request-light": ["request-light@0.5.8", "", {}, "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="],
 
-    "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "yaml-language-server/yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
 
-    "ansi-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
+
+    "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -962,7 +1067,5 @@
     "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
-
-    "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^19"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.9.9",
     "@tailwindcss/vite": "^4",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -1,79 +1,105 @@
-import { useEffect, useState, useRef, useCallback } from "react";
-import type { ReactNode, KeyboardEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
 import type { GitHubRepo } from "../lib/github";
-import { ROLES, EXPERIENCES, SOCIALS, FEATURED_PROJECTS, SKILLS } from "../lib/data";
-
+import {
+  AVAILABILITY,
+  ENGINEERING_PRINCIPLES,
+  EXPERIENCES,
+  FEATURED_PROJECTS,
+  OPERATING_SIGNALS,
+  PROFILE,
+  SKILLS,
+  SOCIALS,
+} from "../lib/data";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Hooks
 // ─────────────────────────────────────────────────────────────────────────────
 
-function useTyping(strings: string[], speed = 80, deleteSpeed = 40, pause = 2200) {
-  const [text, setText] = useState('');
-  const [idx, setIdx] = useState(0);
-  const [deleting, setDeleting] = useState(false);
-
-  useEffect(() => {
-    const current = strings[idx];
-    const timeout = setTimeout(() => {
-      if (!deleting) {
-        setText(current.slice(0, text.length + 1));
-        if (text.length === current.length) {
-          setTimeout(() => setDeleting(true), pause);
-          return;
-        }
-      } else {
-        setText(current.slice(0, text.length - 1));
-        if (text.length === 0) {
-          setDeleting(false);
-          setIdx((i) => (i + 1) % strings.length);
-        }
-      }
-    }, deleting ? deleteSpeed : speed);
-    return () => clearTimeout(timeout);
-  }, [text, idx, deleting, strings, speed, deleteSpeed, pause]);
-
-  return text;
-}
-
 function useReveal() {
   const ref = useRef<HTMLDivElement>(null);
   const [shown, setShown] = useState(false);
+
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
-    const obs = new IntersectionObserver(([e]) => { if (e.isIntersecting) { setShown(true); obs.unobserve(el); } }, { threshold: 0.08 });
+    const obs = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setShown(true);
+          obs.unobserve(el);
+        }
+      },
+      { threshold: 0.08 },
+    );
     obs.observe(el);
     return () => obs.disconnect();
   }, []);
+
   return { ref, shown };
 }
 
 function useScrollProgress() {
-  const [p, setP] = useState(0);
+  const [progress, setProgress] = useState(0);
+
   useEffect(() => {
-    const h = () => { const t = document.documentElement.scrollHeight - window.innerHeight; setP(t > 0 ? window.scrollY / t : 0); };
-    window.addEventListener('scroll', h, { passive: true });
-    return () => window.removeEventListener('scroll', h);
+    const onScroll = () => {
+      const total = document.documentElement.scrollHeight - window.innerHeight;
+      setProgress(total > 0 ? window.scrollY / total : 0);
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
   }, []);
-  return p;
+
+  return progress;
+}
+
+function trackEvent(name: string, params: Record<string, string>) {
+  const gtag = (window as unknown as { gtag?: (...args: unknown[]) => void }).gtag;
+  gtag?.("event", name, params);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Small components
 // ─────────────────────────────────────────────────────────────────────────────
 
-function Reveal({ children, className = '', delay = 0 }: { children: ReactNode; className?: string; delay?: number }) {
+function Reveal({ children, className = "", delay = 0 }: { children: ReactNode; className?: string; delay?: number }) {
   const { ref, shown } = useReveal();
-  return <div ref={ref} className={`reveal ${shown ? 'shown' : ''} ${className}`} style={{ transitionDelay: `${delay}ms` }}>{children}</div>;
+  return (
+    <div ref={ref} className={`reveal ${shown ? "shown" : ""} ${className}`} style={{ transitionDelay: `${delay}ms` }}>
+      {children}
+    </div>
+  );
 }
 
-function SectionLabel({ children }: { children: ReactNode }) {
+function SectionLabel({ id, number, children }: { id: string; number: string; children: ReactNode }) {
   return (
-    <div className="flex items-center gap-3 mb-10">
-      <span className="font-mono text-xs font-bold uppercase tracking-widest" style={{ color: 'var(--color-green)' }}>{children}</span>
-      <span className="section-label-line" />
+    <div className="section-ruler">
+      <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-dim">trace {number}</p>
+      <h2 id={id} className="section-heading">
+        {children}
+      </h2>
     </div>
+  );
+}
+
+function SocialLink({ social, compact = false }: { social: (typeof SOCIALS)[number]; compact?: boolean }) {
+  return (
+    <a
+      href={social.href}
+      target="_blank"
+      rel="noreferrer noopener"
+      aria-label={social.label}
+      title={social.label}
+      className={compact ? "icon-link compact" : "icon-link"}
+      onClick={() => trackEvent("social_click", { label: social.label })}
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox={social.vb} fill="currentColor" aria-hidden="true">
+        <path d={social.icon} />
+      </svg>
+      {!compact && <span>{social.label}</span>}
+    </a>
   );
 }
 
@@ -82,421 +108,370 @@ function SectionLabel({ children }: { children: ReactNode }) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 const NEOFETCH = [
-  '',
-  '   ██╗██████╗     jonathan@dev',
-  '   ██║██╔══██╗    ──────────────────',
-  '   ██║██████╔╝    OS:        Astro 5 / GitHub Pages',
-  '██ ██║██╔═══╝     Shell:     TypeScript 5.x',
-  '╚███╔╝██║         Uptime:    12+ years in tech',
-  ' ╚══╝ ╚═╝         Packages:  React 19, Tailwind v4',
-  '                   Languages: C#, Rust, Go, Python, TS',
-  '                   Location:  Itanhaém, Brazil 🇧🇷',
-  '',
+  "",
+  "   ██╗██████╗     jonathan@workstation",
+  "   ██║██╔══██╗    runtime:   Astro 6 / React 19",
+  "   ██║██████╔╝    shell:     TypeScript 6.x",
+  "██ ██║██╔═══╝     uptime:    12+ years in production code",
+  "╚███╔╝██║         region:    Brazil, remote-first",
+  " ╚══╝ ╚═╝         focus:     backend systems, delivery, reliability",
+  "",
 ];
 
 function runCmd(cmd: string): string[] {
   const c = cmd.trim().toLowerCase();
   const map: Record<string, string[]> = {
-    help: ['', '  help · about · skills · contact · neofetch', '  ls · cat about.txt · git log · whoami · pwd · date', '  sudo hire me · rm -rf / · clear · exit', ''],
-    whoami: ['jonathan.peris — Software Engineer @ Derivative Path'],
+    help: ["", "  help · about · stack · contact · neofetch", "  ls · cat availability.txt · git log · whoami · pwd · date", "  sudo hire me · clear · exit", ""],
+    whoami: ["jonathan.peris", "software engineer", "backend architecture and reliable delivery"],
     neofetch: NEOFETCH,
-    pwd: ['/home/jonathan/portfolio'],
+    pwd: ["/home/jonathan/portfolio"],
     date: [new Date().toString()],
-    ls: ['about.txt  experience/  projects/  resume.pdf  .easter-egg'],
-    'cat about.txt': ['', 'Software Engineer · 12+ years · .NET & Fintech', 'Currently building financial software @ Derivative Path', 'Exploring Rust, Go, Python on the side', ''],
-    about: ['', '  Jonathan Peris — Software Engineer', '  12+ years · .NET · Fintech · Cloud', '  Itanhaém, Brazil → Working remote for US companies', '', '  "A Vingança nunca é plena, mata a alma e a envenena."', '  — Seu Madruga', ''],
-    skills: ['', '  Languages    C#, Rust, Go, Python, TypeScript', '  Backend      .NET Core+, ASP.NET Core, EF Core, MAUI', '  Arch         CQRS, DDD, Microservices, Hexagonal, Clean', '  Cloud        Azure, Docker, Kubernetes, CI/CD', '  DB           SQL Server, PostgreSQL', '  Frontend     Blazor, React/Next.js, Angular', ''],
-    contact: ['', '  GitHub     github.com/jonathanperis', '  LinkedIn   linkedin.com/in/jonathan-peris', '  Email      jperis.silva@gmail.com', '  X          x.com/jperis_silva', ''],
-    'git log': ['', ...EXPERIENCES.slice(0, 5).map((e, i) => `  ${String(i).padStart(2)} ${e.period.split(' — ')[0].padEnd(14)} ${e.title} @ ${e.company}`), '  ... +5 more', ''],
-    'sudo hire me': ['', '  [sudo] password for recruiter: ********', '  ✓ Verified.', '', '  Offer letter generated.', '  → linkedin.com/in/jonathan-peris', ''],
-    'rm -rf /': ['', '  rm: nice try. this terminal has plot armor.', ''],
-    'cat .easter-egg': ['', '  🎮 You found me!', '  Congrats, you\'re thorough. That\'s a great quality.', ''],
+    ls: ["availability.txt  architecture/  experience.log  projects/  resume.pdf"],
+    "cat availability.txt": [AVAILABILITY.full],
+    about: ["", "  Jonathan Peris", "  Software Engineer, 12+ years", "  C#, .NET, Azure, CQRS, DDD", "  Remote from Brazil", ""],
+    stack: ["", "  backend      C#, .NET Core+, ASP.NET Core", "  architecture CQRS, DDD, microservices, hexagonal", "  delivery     Azure, Docker, Kubernetes, CI/CD", "  data         SQL Server, PostgreSQL", ""],
+    contact: ["", "  GitHub     github.com/jonathanperis", "  LinkedIn   linkedin.com/in/jonathan-peris", "  Email      jperis.silva@gmail.com", ""],
+    "git log": ["", ...EXPERIENCES.slice(0, 5).map((e, i) => `  ${String(i).padStart(2, "0")} ${e.period.split(" — ")[0].padEnd(9)} ${e.title} @ ${e.company}`), "  ... +5 earlier commits", ""],
+    "sudo hire me": ["", "  [sudo] password for recruiter: ********", "  access granted", "  route opened: linkedin.com/in/jonathan-peris", ""],
   };
+
   if (map[c]) return map[c];
-  if (c.startsWith('echo ')) return [cmd.trim().slice(5)];
-  if (c.startsWith('sudo ')) return [`  permission denied: ${cmd.trim().slice(5)}`];
-  if (c.startsWith('cd ')) return [`  bash: cd: ${cmd.trim().slice(3)}: No such file or directory`];
-  if (c === 'clear') return ['__CLEAR__'];
-  if (c === 'exit' || c === 'quit') return ['__EXIT__'];
-  return [`  bash: ${cmd.trim().split(' ')[0]}: command not found`];
+  if (c.startsWith("echo ")) return [cmd.trim().slice(5)];
+  if (c === "clear") return ["__CLEAR__"];
+  if (c === "exit" || c === "quit") return ["__EXIT__"];
+  return [`  command not found: ${cmd.trim().split(" ")[0]}`];
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Skills section helpers
-// ─────────────────────────────────────────────────────────────────────────────
-
-const SKILL_CATEGORIES: Array<{ key: keyof typeof SKILLS; label: string; tagClass: string }> = [
-  { key: 'languages',    label: 'Languages',    tagClass: 'tag-cyan' },
-  { key: 'backend',      label: 'Backend',      tagClass: 'tag' },
-  { key: 'architecture', label: 'Architecture', tagClass: 'tag-purple' },
-  { key: 'cloud',        label: 'Cloud & DevOps', tagClass: 'tag-amber' },
-  { key: 'databases',    label: 'Databases',    tagClass: 'tag-rose' },
-  { key: 'frontend',     label: 'Frontend',     tagClass: 'tag-cyan' },
+const SKILL_GROUPS: Array<{ key: keyof typeof SKILLS; label: string; path: string }> = [
+  { key: "backend", label: "backend runtime", path: "/stack/backend" },
+  { key: "architecture", label: "architecture", path: "/stack/boundaries" },
+  { key: "cloud", label: "delivery", path: "/stack/delivery" },
+  { key: "databases", label: "data", path: "/stack/data" },
+  { key: "languages", label: "languages", path: "/stack/languages" },
+  { key: "frontend", label: "interface", path: "/stack/interface" },
 ];
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Main
-// ─────────────────────────────────────────────────────────────────────────────
+function projectLane(project: (typeof FEATURED_PROJECTS)[number]) {
+  const text = `${project.name} ${project.tags.join(" ")}`.toLowerCase();
+  if (text.includes("rinha") || text.includes("k6") || text.includes("performance")) return "load path";
+  if (text.includes("clean") || text.includes(".net")) return "system design";
+  if (text.includes("game") || text.includes("sdl") || text.includes("lynx")) return "runtime lab";
+  return "field note";
+}
 
 export default function Portfolio({ projects }: { projects: GitHubRepo[] }) {
-  const typedRole = useTyping(ROLES);
   const scrollProgress = useScrollProgress();
+  const featuredSlugs = useMemo(() => new Set(FEATURED_PROJECTS.map((fp) => fp.slug)), []);
 
-  // Terminal
   const [termOpen, setTermOpen] = useState(false);
-  const [termInput, setTermInput] = useState('');
-  const [termHist, setTermHist] = useState<string[]>(['  Welcome to jonathan.sh v2.0', '  Type "help" for commands.', '']);
+  const [termInput, setTermInput] = useState("");
+  const [termHist, setTermHist] = useState<string[]>(["  jonathan.sh ready", "  Type \"help\" for commands.", ""]);
   const [cmdHist, setCmdHist] = useState<string[]>([]);
   const [histIdx, setHistIdx] = useState(-1);
   const termEndRef = useRef<HTMLDivElement>(null);
   const termInRef = useRef<HTMLInputElement>(null);
+  const termCloseRef = useRef<HTMLButtonElement>(null);
+  const lastFocusedRef = useRef<HTMLElement | null>(null);
   const konamiRef = useRef<string[]>([]);
 
-  // Konami
   useEffect(() => {
-    const K = ['ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight', 'b', 'a'];
-    const h = (e: KeyboardEvent) => {
+    const K = ["ArrowUp", "ArrowUp", "ArrowDown", "ArrowDown", "ArrowLeft", "ArrowRight", "ArrowLeft", "ArrowRight", "b", "a"];
+    const onKey = (e: globalThis.KeyboardEvent) => {
       if (termOpen) return;
       konamiRef.current.push(e.key);
       konamiRef.current = konamiRef.current.slice(-10);
-      if (konamiRef.current.join(',') === K.join(',')) { setTermOpen(true); konamiRef.current = []; }
+      if (konamiRef.current.join(",") === K.join(",")) {
+        lastFocusedRef.current = document.activeElement as HTMLElement | null;
+        setTermOpen(true);
+        konamiRef.current = [];
+      }
     };
-    window.addEventListener('keydown', h);
-    return () => window.removeEventListener('keydown', h);
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
   }, [termOpen]);
 
   useEffect(() => {
-    if (termOpen) { termEndRef.current?.scrollIntoView({ behavior: 'smooth' }); termInRef.current?.focus(); }
+    if (!termOpen) return;
+    termEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    termInRef.current?.focus();
   }, [termHist, termOpen]);
+
+  const closeTerminal = useCallback(() => {
+    setTermOpen(false);
+    setTermHist(["  jonathan.sh ready", "  Type \"help\" for commands.", ""]);
+    requestAnimationFrame(() => lastFocusedRef.current?.focus());
+  }, []);
 
   const submit = useCallback(() => {
     if (!termInput.trim()) return;
-    const r = runCmd(termInput);
-    setCmdHist(p => [...p, termInput]);
+    const result = runCmd(termInput);
+    setCmdHist((prev) => [...prev, termInput]);
     setHistIdx(-1);
-    if (r[0] === '__CLEAR__') setTermHist([]);
-    else if (r[0] === '__EXIT__') { setTermOpen(false); setTermHist(['  Welcome to jonathan.sh v2.0', '  Type "help" for commands.', '']); }
-    else setTermHist(p => [...p, `$ ${termInput}`, ...r]);
-    setTermInput('');
-  }, [termInput]);
+    if (result[0] === "__CLEAR__") setTermHist([]);
+    else if (result[0] === "__EXIT__") closeTerminal();
+    else setTermHist((prev) => [...prev, `$ ${termInput}`, ...result]);
+    setTermInput("");
+  }, [closeTerminal, termInput]);
 
-  const termKey = useCallback((e: KeyboardEvent) => {
-    if (e.key === 'Enter') submit();
-    else if (e.key === 'Escape') setTermOpen(false);
-    else if (e.key === 'ArrowUp') { e.preventDefault(); if (cmdHist.length) { const n = histIdx === -1 ? cmdHist.length - 1 : Math.max(0, histIdx - 1); setHistIdx(n); setTermInput(cmdHist[n]); } }
-    else if (e.key === 'ArrowDown') { e.preventDefault(); if (histIdx !== -1) { const n = histIdx + 1; if (n >= cmdHist.length) { setHistIdx(-1); setTermInput(''); } else { setHistIdx(n); setTermInput(cmdHist[n]); } } }
-    else if (e.key === 'l' && e.ctrlKey) { e.preventDefault(); setTermHist([]); }
-  }, [submit, cmdHist, histIdx]);
+  const termKey = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") submit();
+      else if (e.key === "Escape") closeTerminal();
+      else if (e.key === "Tab") {
+        e.preventDefault();
+        termCloseRef.current?.focus();
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        if (cmdHist.length) {
+          const next = histIdx === -1 ? cmdHist.length - 1 : Math.max(0, histIdx - 1);
+          setHistIdx(next);
+          setTermInput(cmdHist[next]);
+        }
+      } else if (e.key === "ArrowDown") {
+        e.preventDefault();
+        if (histIdx !== -1) {
+          const next = histIdx + 1;
+          if (next >= cmdHist.length) {
+            setHistIdx(-1);
+            setTermInput("");
+          } else {
+            setHistIdx(next);
+            setTermInput(cmdHist[next]);
+          }
+        }
+      } else if (e.key === "l" && e.ctrlKey) {
+        e.preventDefault();
+        setTermHist([]);
+      }
+    },
+    [closeTerminal, cmdHist, histIdx, submit],
+  );
+
+  const openTerminal = () => {
+    lastFocusedRef.current = document.activeElement as HTMLElement | null;
+    setTermOpen(true);
+    trackEvent("terminal_open", { source: "hero" });
+  };
 
   return (
     <>
-      {/* Scroll progress */}
       <div className="scroll-bar fixed top-0 left-0 right-0 h-[2px] z-50" style={{ transform: `scaleX(${scrollProgress})` }} />
 
-      <div className="relative z-10 mx-auto max-w-6xl px-6 md:px-12">
-
-        {/* ━━ Nav ━━ */}
-        <nav className="sticky top-0 z-40 -mx-6 md:-mx-12 px-6 md:px-12 py-4 bg-bg/80 backdrop-blur-lg border-b border-transparent" style={{ borderColor: scrollProgress > 0.02 ? 'var(--color-border)' : 'transparent' }}>
-          <div className="flex items-center justify-between max-w-6xl mx-auto">
-            <a href="/" className="font-mono text-sm font-bold text-text hover:text-violet transition-colors">jp<span style={{ color: 'var(--color-violet)' }}>.</span></a>
-            <div className="flex items-center gap-6">
-              {["about", "experience", "projects"].map((s) => (
-                <a key={s} href={`#${s}`} className="font-mono text-xs text-dim hover:text-text transition-colors">{s}</a>
-              ))}
-              <a href="/resume" className="font-mono text-xs text-bg px-3 py-1 rounded-md transition-colors font-semibold" style={{ color: 'var(--color-bg)', background: 'var(--color-violet)' }} onMouseOver={e => e.currentTarget.style.background = 'var(--color-violet-dim)'} onMouseOut={e => e.currentTarget.style.background = 'var(--color-violet)'}>resume</a>
-            </div>
+      <div className="site-shell relative z-10">
+        <nav className="route-nav" aria-label="Primary navigation">
+          <a href="/" className="route-mark" aria-label="Jonathan Peris home">
+            jp<span>.</span>
+          </a>
+          <div className="route-links">
+            <a href="#profile">/profile</a>
+            <a href="#trace">/trace</a>
+            <a href="#workbench">/workbench</a>
+            <a href="/resume" className="route-resume" onClick={() => trackEvent("cta_click", { label: "nav_resume" })}>
+              resume.pdf
+            </a>
           </div>
         </nav>
 
-        {/* ━━ Hero ━━ */}
-        <section className="relative pt-24 pb-20 md:pt-32 md:pb-28 overflow-visible max-w-4xl">
-          <div className="hero-glow" aria-hidden="true" />
-          <Reveal>
-            <div className="mb-6 inline-flex items-center gap-2 rounded-full border px-3 py-1" style={{ borderColor: 'rgba(74,222,128,0.2)', backgroundColor: 'var(--color-violet-tint)' }}>
-              <span className="relative flex h-2 w-2">
-                <span className="absolute inline-flex h-full w-full animate-ping rounded-full opacity-60" style={{ backgroundColor: 'var(--color-violet)' }} />
-                <span className="relative inline-flex h-2 w-2 rounded-full" style={{ backgroundColor: 'var(--color-violet)' }} />
-              </span>
-              <span className="font-mono text-xs" style={{ color: 'var(--color-violet)' }}>Available for hire</span>
-            </div>
-          </Reveal>
-          <Reveal delay={100}>
-            <h1 style={{ fontFamily: 'var(--font-display)' }} className="text-6xl md:text-8xl font-extrabold tracking-tight text-text leading-[1.05]">
-              Jonathan Peris
-            </h1>
-          </Reveal>
-          <Reveal delay={200}>
-            <p className="mt-4 font-mono text-lg md:text-xl h-8">
-              <span style={{ color: 'var(--color-green)' }}>{typedRole}</span>
-              <span className="typing-cursor" />
-            </p>
-          </Reveal>
-          <Reveal delay={300}>
-            <p className="mt-6 text-muted leading-relaxed max-w-xl text-base">
-              12+ years building enterprise-grade software with .NET and modern cloud technologies. Specializing in Fintech, clean architecture, and systems that scale.
-            </p>
-          </Reveal>
-          <Reveal delay={400}>
-            <div className="mt-8 flex items-center gap-4 group">
-              {SOCIALS.map((s) => (
-                <a key={s.label} href={s.href} target="_blank" rel="noreferrer noopener" aria-label={s.label} title={s.label}
-                  className="text-dim transition-colors duration-300" onMouseOver={e => e.currentTarget.style.color = 'var(--color-violet)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-dim)'}>
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox={s.vb} fill="currentColor" className="h-5 w-5"><path d={s.icon} /></svg>
-                </a>
-              ))}
-            </div>
-          </Reveal>
-
-          {/* Code snippet */}
-          <Reveal delay={500}>
-            <div className="mt-12 code-block code-block-accent">
-              <div className="titlebar">
-                <div className="dots"><span className="dot dot-red" /><span className="dot dot-yellow" /><span className="dot dot-green" /></div>
-                <span className="font-mono text-xs text-dim">developer.ts</span>
+        <main>
+          <section className="kernel-hero" aria-labelledby="hero-title">
+            <div className="scanline" aria-hidden="true" />
+            <Reveal className="hero-copy">
+              <p className="status-pill"><span aria-hidden="true" />{AVAILABILITY.short}</p>
+              <h1 id="hero-title">Jonathan Peris</h1>
+              <p className="role-line"><span>Backend architecture / .NET / Azure</span><span className="typing-cursor" aria-hidden="true" /></p>
+              <p className="hero-lede">
+                I build backend systems that can be understood, operated, and changed after they meet production traffic.
+              </p>
+              <div className="hero-actions">
+                <a href="/resume" className="primary-action" onClick={() => trackEvent("cta_click", { label: "hero_resume" })}>View resume</a>
+                <a href="https://www.linkedin.com/in/jonathan-peris/" target="_blank" rel="noreferrer noopener" className="secondary-action" onClick={() => trackEvent("cta_click", { label: "hero_linkedin" })}>Contact on LinkedIn</a>
+                <button type="button" className="ghost-action" onClick={openTerminal}>Open shell</button>
               </div>
-              <pre className="p-5 font-mono text-sm leading-relaxed overflow-x-auto">
-                <code>
-                  <span className="text-purple">const</span> <span className="text-text">developer</span> <span className="text-purple">=</span> {"{\n"}
-                  {"  "}<span className="text-text">name</span><span className="text-dim">:</span>       <span className="text-green">&quot;Jonathan Peris&quot;</span>,{"\n"}
-                  {"  "}<span className="text-text">role</span><span className="text-dim">:</span>       <span className="text-green">&quot;Software Engineer&quot;</span>,{"\n"}
-                  {"  "}<span className="text-text">location</span><span className="text-dim">:</span>   <span className="text-green">&quot;Itanhaém, Brazil&quot;</span>,{"\n"}
-                  {"  "}<span className="text-text">experience</span><span className="text-dim">:</span> <span className="text-green">&quot;12+ years&quot;</span>,{"\n"}
-                  {"  "}<span className="text-text">focus</span><span className="text-dim">:</span>      [<span className="text-green">&quot;.NET&quot;</span>, <span className="text-green">&quot;Fintech&quot;</span>, <span className="text-green">&quot;Cloud&quot;</span>],{"\n"}
-                  {"  "}<span className="text-text">languages</span><span className="text-dim">:</span>  [<span className="text-green">&quot;C#&quot;</span>, <span className="text-green">&quot;Rust&quot;</span>, <span className="text-green">&quot;Go&quot;</span>, <span className="text-green">&quot;Python&quot;</span>],{"\n"}
-                  {"  "}<span className="text-text">available</span><span className="text-dim">:</span>  <span className="text-cyan">true</span>,{"\n"}
-                  {"}"};
-                </code>
-              </pre>
-            </div>
-          </Reveal>
-        </section>
-
-        {/* ━━ About ━━ */}
-        <section id="about" className="py-16 scroll-mt-20">
-          <Reveal><SectionLabel>About</SectionLabel></Reveal>
-          <Reveal delay={100}>
-            <div className="text-muted leading-relaxed space-y-4 text-base">
-              <p>
-                I specialize in <span className="text-text font-semibold">.NET</span> and <span className="text-text font-semibold">Fintech</span> — currently building core financial modules for a capital markets platform at <span className="text-text font-semibold">Derivative Path</span>.
-              </p>
-              <p>
-                My work spans <span className="text-text font-semibold">.NET Core+</span>, <span className="text-text font-semibold">ASP.NET Core</span>, <span className="text-text font-semibold">Entity Framework</span>, and <span className="text-text font-semibold">MAUI</span>. I design systems with <span className="text-text font-semibold">CQRS</span>, <span className="text-text font-semibold">DDD</span>, <span className="text-text font-semibold">Microservices</span>, <span className="text-text font-semibold">Hexagonal Architecture</span>, and <span className="text-text font-semibold">Cloud-Native</span> principles — always building for durability.
-              </p>
-              <p>
-                I&apos;ve delivered across <span className="text-text font-semibold">financial services</span>, <span className="text-text font-semibold">automotive</span> (Mercedes-Benz/T-Systems), <span className="text-text font-semibold">EdTech</span>, healthcare, retail, and insurance. Strong DevOps background with <span className="text-text font-semibold">Azure</span>, <span className="text-text font-semibold">Docker</span>, and CI/CD.
-              </p>
-              <p>
-                Beyond .NET, I explore <span className="text-text font-semibold">Rust</span>, <span className="text-text font-semibold">Go</span>, and <span className="text-text font-semibold">Python</span> — driven by curiosity about performance, concurrency, and the next generation of systems.
-              </p>
-            </div>
-          </Reveal>
-        </section>
-
-        {/* ━━ Stack ━━ */}
-        <section className="py-16 scroll-mt-20">
-          <Reveal><SectionLabel>{"// stack"}</SectionLabel></Reveal>
-          <div className="grid gap-3 sm:grid-cols-2 max-w-4xl">
-            {SKILL_CATEGORIES.map(({ key, label, tagClass }, i) => (
-              <Reveal key={key} delay={i * 60}>
-                <div className="card p-4 h-full">
-                  <p className="font-mono text-[10px] uppercase tracking-widest text-dim mb-3">{label}</p>
-                  <div className="flex flex-wrap gap-1.5">
-                    {SKILLS[key].map((skill) => (
-                      <span key={skill} className={tagClass}>{skill}</span>
-                    ))}
-                  </div>
-                </div>
-              </Reveal>
-            ))}
-          </div>
-        </section>
-
-        {/* ━━ Experience ━━ */}
-        <section id="experience" className="py-16 scroll-mt-20">
-          <Reveal><SectionLabel>Experience</SectionLabel></Reveal>
-          <div className="relative pl-4 space-y-1 max-w-4xl">
-            {EXPERIENCES.map((exp, i) => (
-              <Reveal key={`${exp.company}-${exp.period}`} delay={i * 60}>
-                <div className={`exp-entry group ${i === 0 ? 'exp-entry-current' : 'py-5'}`}>
-                  <span className={`exp-dot ${i === 0 ? 'exp-dot-active' : ''}`} />
-                  <div className="flex flex-col sm:flex-row sm:items-baseline sm:gap-3 mb-1">
-                    <h3 style={{ fontFamily: 'var(--font-display)' }} className="text-text font-bold text-lg">
-                      {exp.title}<span className="text-dim font-normal text-base"> · </span><span className="text-muted font-normal text-base">{exp.company}</span>
-                    </h3>
-                  </div>
-                  <div className="font-mono text-xs text-dim mb-3">
-                    {exp.period}<span className="mx-2">·</span>{exp.location}
-                  </div>
-                  <p className="text-sm text-muted leading-relaxed mb-3">{exp.description}</p>
-                  <div className="flex flex-wrap gap-1.5">
-                    {exp.tags.map((t) => (<span key={t} className="tag">{t}</span>))}
-                  </div>
-                </div>
-              </Reveal>
-            ))}
-          </div>
-        </section>
-
-        {/* ━━ Featured Projects ━━ */}
-        <section id="projects" className="py-16 scroll-mt-20">
-          <Reveal><SectionLabel>Featured Projects</SectionLabel></Reveal>
-          <div className="bento-grid">
-            {FEATURED_PROJECTS.map((fp, i) => {
-              // Assign bento column spans — alternate between wide/narrow
-              const colSpan = i % 3 === 0 ? 'bento-col-7' : i % 3 === 1 ? 'bento-col-5' : 'bento-col-12';
-              const isWide = i % 3 === 2;
-              return (
-                <Reveal key={fp.slug} delay={i * 80} className={colSpan}>
-                  <div className="bento-card h-full group">
-                    <div className="project-card-accent" style={{ background: fp.langColor }} />
-                    <div className={`p-6 h-full flex flex-col ${isWide ? 'md:flex-row md:gap-6 md:items-center' : ''}`}>
-                      <div className={isWide ? 'flex-1' : 'flex-1'}>
-                        <div className="flex items-center gap-2 mb-3">
-                          <span className="h-3 w-3 rounded-full flex-shrink-0" style={{ backgroundColor: fp.langColor }} />
-                          <h3 style={{ fontFamily: 'var(--font-display)' }} className="text-lg font-bold text-text transition-colors" onMouseOver={e => e.currentTarget.style.color = 'var(--color-violet-light)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-text)'}>{fp.name}</h3>
-                          <span className="font-mono text-xs text-dim ml-1">{fp.lang}</span>
-                        </div>
-                        <p className="text-sm text-muted leading-relaxed mb-4">{fp.description}</p>
-                        <div className="flex flex-wrap gap-1.5 mb-4">
-                          {fp.tags.map((t) => (<span key={t} className="tag">{t}</span>))}
-                        </div>
-                      </div>
-                      <div className={`flex items-center gap-3 mt-auto pt-4 ${isWide ? 'md:flex-col md:items-end md:justify-center md:pt-0' : ''}`}>
-                        <a href={fp.repoUrl} target="_blank" rel="noreferrer noopener"
-                          className="inline-flex items-center gap-1.5 font-mono text-xs text-muted transition-colors" onMouseOver={e => e.currentTarget.style.color = 'var(--color-text)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-muted)'}>
-                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
-                            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-                          </svg>
-                          Source Code
-                        </a>
-                        <a href={fp.liveUrl} target="_blank" rel="noreferrer noopener"
-                          className="inline-flex items-center gap-1.5 font-mono text-xs font-semibold border rounded-md px-2.5 py-1 transition-colors"
-                          style={{ color: 'var(--color-violet-light)', borderColor: 'rgba(74,222,128,0.3)', background: 'var(--color-violet-tint)' }}
-                          onMouseOver={e => e.currentTarget.style.background = 'rgba(74,222,128,0.15)'}
-                          onMouseOut={e => e.currentTarget.style.background = 'var(--color-violet-tint)'}>
-                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-3.5 w-3.5">
-                            <path fillRule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5zm7.25-.182a.75.75 0 01.75-.75h3.5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0V6.56l-5.22 5.22a.75.75 0 11-1.06-1.06l5.22-5.22h-2.44a.75.75 0 01-.75-.75z" clipRule="evenodd" />
-                          </svg>
-                          Visit website
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                </Reveal>
-              );
-            })}
-          </div>
-        </section>
-
-        {/* ━━ More Projects ━━ */}
-        <section className="py-16 scroll-mt-20">
-          <Reveal><SectionLabel>More Projects</SectionLabel></Reveal>
-          <div className="grid gap-3 sm:grid-cols-2">
-            {projects.filter((p) => !FEATURED_PROJECTS.some((fp) => fp.slug === p.title) && p.title !== '.github').map((p, i) => (
-              <Reveal key={p.title} delay={i * 60}>
-                <a href={p.url} target="_blank" rel="noreferrer noopener"
-                  className="card card-glow p-5 block group h-full">
-                  <div className="flex items-center gap-2 mb-2">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-4 w-4 text-dim transition-colors flex-shrink-0" onMouseOver={e => e.currentTarget.style.color = 'var(--color-violet)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-dim)'}>
-                      <path d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5zm10.5-1h-8a1 1 0 00-1 1v6.708A2.486 2.486 0 014.5 9h8.5zM5 12.25v3.25a.25.25 0 00.4.2l1.45-1.087a.25.25 0 01.3 0L8.6 15.7a.25.25 0 00.4-.2v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25z" />
-                    </svg>
-                    <span className="font-mono text-sm font-semibold text-text transition-colors" onMouseOver={e => e.currentTarget.style.color = 'var(--color-violet)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-text)'}>{p.title}</span>
-                    {p.stars > 0 && (
-                      <span className="ml-auto flex items-center gap-1 text-xs text-dim font-mono">
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3">
-                          <path d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z" />
-                        </svg>
-                        {p.stars}
-                      </span>
-                    )}
-                  </div>
-                  <p className="text-xs text-muted leading-relaxed mb-3">{p.description}</p>
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-1.5">
-                      <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: p.langColor || '#888' }} />
-                      <span className="text-xs text-dim font-mono">{p.lang}</span>
-                    </div>
-                    {p.homepageUrl && (
-                      <span
-                        onClick={(e) => { e.preventDefault(); e.stopPropagation(); window.open(p.homepageUrl!, '_blank'); }}
-                        className="inline-flex items-center gap-1 font-mono text-[10px] font-semibold border rounded-md px-2 py-0.5 transition-colors cursor-pointer"
-                        style={{ color: 'var(--color-violet-light)', borderColor: 'rgba(74,222,128,0.3)', background: 'var(--color-violet-tint)' }}
-                        onMouseOver={e => e.currentTarget.style.background = 'rgba(74,222,128,0.15)'}
-                        onMouseOut={e => e.currentTarget.style.background = 'var(--color-violet-tint)'}
-                      >
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-3 w-3">
-                          <path fillRule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5zm7.25-.182a.75.75 0 01.75-.75h3.5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0V6.56l-5.22 5.22a.75.75 0 11-1.06-1.06l5.22-5.22h-2.44a.75.75 0 01-.75-.75z" clipRule="evenodd" />
-                        </svg>
-                        Visit website
-                      </span>
-                    )}
-                  </div>
-                </a>
-              </Reveal>
-            ))}
-          </div>
-          <Reveal delay={400}>
-            <div className="mt-8 text-center">
-              <a href="https://github.com/jonathanperis" target="_blank" rel="noreferrer noopener"
-                className="inline-flex items-center gap-2 font-mono text-sm text-muted transition-colors" onMouseOver={e => e.currentTarget.style.color = 'var(--color-violet-light)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-muted)'}>
-                View all on GitHub
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
-                  <path fillRule="evenodd" d="M5.22 14.78a.75.75 0 001.06 0l7.22-7.22v5.69a.75.75 0 001.5 0v-7.5a.75.75 0 00-.75-.75h-7.5a.75.75 0 000 1.5h5.69l-7.22 7.22a.75.75 0 000 1.06z" clipRule="evenodd" />
-                </svg>
-              </a>
-            </div>
-          </Reveal>
-        </section>
-
-        {/* ━━ Footer ━━ */}
-        <footer className="pt-8 pb-16 relative">
-          <div className="footer-line mb-8" />
-          <Reveal>
-            <div className="relative text-center space-y-4">
-              <div className="flex items-center justify-center gap-6">
-                {SOCIALS.map((s) => (
-                  <a key={s.label} href={s.href} target="_blank" rel="noreferrer noopener" title={s.label}
-                    className="text-dim transition-colors" onMouseOver={e => e.currentTarget.style.color = 'var(--color-violet-light)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-dim)'}>
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox={s.vb} fill="currentColor" className="h-5 w-5"><path d={s.icon} /></svg>
-                  </a>
+              <div className="signal-strip" aria-label="Operating signals">
+                {OPERATING_SIGNALS.map((signal) => (
+                  <span key={signal.label}><b>{signal.label}</b>{signal.value}</span>
                 ))}
               </div>
-              <p className="font-mono text-xs text-dim">
-                Built with ❤️ by{' '}
-                <a href="https://github.com/jonathanperis" target="_blank" rel="noreferrer noopener" className="font-bold text-dim transition-colors" onMouseOver={e => e.currentTarget.style.color = 'var(--color-violet-light)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-dim)'}>Me</a>
-                {' '}and my{' '}
-                <a href="https://claude.ai/" target="_blank" rel="noreferrer noopener" className="font-bold text-dim transition-colors" onMouseOver={e => e.currentTarget.style.color = 'var(--color-violet-light)'} onMouseOut={e => e.currentTarget.style.color = 'var(--color-dim)'}>24/7 Intern</a>
+            </Reveal>
+
+            <Reveal delay={140} className="hero-console-wrap">
+              <div className="hero-console" aria-label="Build ledger summary">
+                <div className="console-top">
+                  <span>deploy-ledger.yaml</span>
+                  <span className="console-state">healthy</span>
+                </div>
+                <pre>{`operator: ${PROFILE.name}\nlocation: ${PROFILE.location}\nstatus: ${AVAILABILITY.full}\nfocus:\n  - backend architecture\n  - delivery discipline\n  - reliable systems\nruntime:\n  years: 12+\n  stack: C# / .NET / Azure / SQL\n  mode: remote-first`}</pre>
+              </div>
+            </Reveal>
+          </section>
+
+          <div className="section-bridge" aria-hidden="true">
+            <span>scroll</span><span>/profile packet follows</span>
+          </div>
+
+          <section id="profile" className="content-section split-section" aria-labelledby="profile-heading">
+            <Reveal>
+              <SectionLabel id="profile-heading" number="01">Profile packet</SectionLabel>
+            </Reveal>
+            <Reveal delay={100} className="packet-card">
+              <p>
+                My best work sits between architecture and execution: defining boundaries, shipping with tests, and keeping systems legible for the next engineer who has to debug them.
               </p>
-              <p className="font-mono text-[10px] text-dim/30 select-none">{"// ↑↑↓↓←→←→BA"}</p>
+              <p>
+                The record spans financial platforms, automotive operations, education, healthcare, retail, insurance, and infrastructure work. The common thread is boring reliability, clean ownership, and enough curiosity to keep improving the runtime.
+              </p>
+            </Reveal>
+            <div className="principle-grid">
+              {ENGINEERING_PRINCIPLES.map((principle, index) => (
+                <Reveal key={principle.title} delay={index * 70}>
+                  <article className="principle-row">
+                    <span>{String(index + 1).padStart(2, "0")}</span>
+                    <div>
+                      <h3>{principle.title}</h3>
+                      <p>{principle.body}</p>
+                    </div>
+                  </article>
+                </Reveal>
+              ))}
             </div>
-          </Reveal>
+          </section>
+
+          <section className="content-section" aria-labelledby="stack-heading">
+            <Reveal>
+              <SectionLabel id="stack-heading" number="02">Capability map</SectionLabel>
+            </Reveal>
+            <div className="capability-grid">
+              {SKILL_GROUPS.map(({ key, label, path }, index) => (
+                <Reveal key={key} delay={index * 45}>
+                  <article className="capability-row">
+                    <p>{path}</p>
+                    <h3>{label}</h3>
+                    <div>
+                      {SKILLS[key].map((skill) => <span key={skill}>{skill}</span>)}
+                    </div>
+                  </article>
+                </Reveal>
+              ))}
+            </div>
+          </section>
+
+          <section id="trace" className="content-section" aria-labelledby="trace-heading">
+            <Reveal>
+              <SectionLabel id="trace-heading" number="03">Experience trace</SectionLabel>
+            </Reveal>
+            <div className="trace-list">
+              {EXPERIENCES.map((exp, index) => (
+                <Reveal key={`${exp.company}-${exp.period}`} delay={index * 45}>
+                  <article className={index === 0 ? "trace-entry current" : "trace-entry"}>
+                    <div className="trace-meta">
+                      <span>{String(index).padStart(2, "0")}</span>
+                      <time>{exp.period}</time>
+                    </div>
+                    <div className="trace-body">
+                      <h3>{exp.title} <span>@ {exp.company}</span></h3>
+                      <p className="trace-location">{exp.location}</p>
+                      <p>{exp.description}</p>
+                      <div>{exp.tags.map((tag) => <span key={tag}>{tag}</span>)}</div>
+                    </div>
+                  </article>
+                </Reveal>
+              ))}
+            </div>
+          </section>
+
+          <section id="workbench" className="content-section" aria-labelledby="workbench-heading">
+            <Reveal>
+              <SectionLabel id="workbench-heading" number="04">Workbench</SectionLabel>
+            </Reveal>
+            <div className="workbench-grid">
+              {FEATURED_PROJECTS.map((project, index) => (
+                <Reveal key={project.slug} delay={index * 70}>
+                  <article className="workbench-card">
+                    <div className="card-head">
+                      <span style={{ backgroundColor: project.langColor }} aria-hidden="true" />
+                      <p>{projectLane(project)}</p>
+                    </div>
+                    <h3>{project.name}</h3>
+                    <p>{project.description}</p>
+                    <div className="project-tags">{project.tags.map((tag) => <span key={tag}>{tag}</span>)}</div>
+                    <div className="project-actions">
+                      <a href={project.repoUrl} target="_blank" rel="noreferrer noopener">Source</a>
+                      <a href={project.liveUrl} target="_blank" rel="noreferrer noopener">Live</a>
+                    </div>
+                  </article>
+                </Reveal>
+              ))}
+            </div>
+          </section>
+
+          <section className="content-section" aria-labelledby="repos-heading">
+            <Reveal>
+              <SectionLabel id="repos-heading" number="05">Repository tail</SectionLabel>
+            </Reveal>
+            <div className="repo-table" role="list">
+              {projects.filter((p) => !featuredSlugs.has(p.title) && p.title !== ".github").slice(0, 8).map((project, index) => (
+                <Reveal key={project.title} delay={index * 35}>
+                  <article role="listitem" className="repo-row">
+                    <a href={project.url} target="_blank" rel="noreferrer noopener">{project.title}</a>
+                    <p>{project.description || "Repository note pending."}</p>
+                    <div>
+                      {project.stars > 0 && <span>{project.stars} stars</span>}
+                      {project.lang && <span>{project.lang}</span>}
+                      {project.homepageUrl && <a href={project.homepageUrl} target="_blank" rel="noreferrer noopener">site</a>}
+                    </div>
+                  </article>
+                </Reveal>
+              ))}
+            </div>
+            <Reveal delay={320}>
+              <a href="https://github.com/jonathanperis" target="_blank" rel="noreferrer noopener" className="github-tail">View all repositories on GitHub</a>
+            </Reveal>
+          </section>
+        </main>
+
+        <footer className="site-footer">
+          <div className="footer-socials">
+            {SOCIALS.map((social) => <SocialLink key={social.label} social={social} compact />)}
+          </div>
+          <p>Built as a small systems manual. Hidden shell: ↑↑↓↓←→←→BA</p>
         </footer>
       </div>
 
-      {/* ━━ Terminal ━━ */}
       {termOpen && (
-        <div className="fixed inset-0 z-50 terminal-backdrop flex items-center justify-center p-4"
-          onClick={(e) => { if (e.target === e.currentTarget) setTermOpen(false); }}>
-          <div className="w-full max-w-2xl rounded-xl border border-border overflow-hidden shadow-2xl shadow-violet/5">
-            <div className="flex items-center gap-2 bg-elevated px-4 py-3 border-b border-border">
-              <div className="flex gap-1.5">
-                <button onClick={() => setTermOpen(false)} className="h-3 w-3 rounded-full bg-[#ff5f57] hover:brightness-110 transition" aria-label="Close" />
-                <span className="h-3 w-3 rounded-full bg-[#febc2e]" />
-                <span className="h-3 w-3 rounded-full bg-[#28c840]" />
-              </div>
-              <span className="font-mono text-xs text-dim ml-2">jonathan.sh</span>
-              <span className="ml-auto font-mono text-[10px] text-dim/40">ESC to close</span>
+        <div className="terminal-backdrop fixed inset-0 z-50 flex items-center justify-center p-4" onClick={(e) => { if (e.target === e.currentTarget) closeTerminal(); }}>
+          <div className="terminal-dialog" role="dialog" aria-modal="true" aria-label="Interactive terminal">
+            <div className="terminal-titlebar">
+              <div className="window-dots" aria-hidden="true"><span /><span /><span /></div>
+              <span>jonathan.sh</span>
+              <button
+                type="button"
+                ref={termCloseRef}
+                onClick={closeTerminal}
+                onKeyDown={(e) => {
+                  if (e.key === "Tab") {
+                    e.preventDefault();
+                    termInRef.current?.focus();
+                  } else if (e.key === "Escape") closeTerminal();
+                }}
+              >
+                Close
+              </button>
             </div>
-            <div className="terminal-body p-4 h-96 overflow-y-auto font-mono text-sm bg-bg"
-              onClick={() => termInRef.current?.focus()}>
-              {termHist.map((line, i) => (
-                <div key={i} className={`whitespace-pre-wrap leading-relaxed ${line.startsWith('$') ? 'text-green' : 'text-muted'}`}>{line}</div>
-              ))}
-              <div className="flex items-center">
-                <span className="text-green mr-2 select-none">$</span>
-                <input ref={termInRef} autoFocus className="flex-1 bg-transparent outline-none text-text caret-green font-mono text-sm"
-                  value={termInput} onChange={(e) => setTermInput(e.target.value)} onKeyDown={termKey}
-                  spellCheck={false} autoComplete="off" autoCapitalize="off" />
+            <div className="terminal-body" onClick={() => termInRef.current?.focus()}>
+              {termHist.map((line, index) => <div key={`${line}-${index}`} className={line.startsWith("$") ? "cmd-line" : "out-line"}>{line}</div>)}
+              <div className="terminal-input-row">
+                <span aria-hidden="true">$</span>
+                <input
+                  ref={termInRef}
+                  autoFocus
+                  value={termInput}
+                  onChange={(e) => setTermInput(e.target.value)}
+                  onKeyDown={termKey}
+                  aria-label="Terminal command"
+                  spellCheck={false}
+                  autoComplete="off"
+                  autoCapitalize="off"
+                />
               </div>
               <div ref={termEndRef} />
             </div>

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -19,6 +19,33 @@ export const PROFILE = {
     "Software Engineer with 12+ years of experience specializing in .NET and Fintech solutions. Proven track record architecting and delivering high-impact, enterprise-grade software. Expertise centered on the modern .NET ecosystem including .NET Core+, ASP.NET Core, Entity Framework, and MAUI. Deeply committed to engineering excellence with CQRS, DDD, Microservices, Hexagonal Architecture, and Cloud-Native principles. Strong DevOps background with Azure, Docker, and CI/CD pipelines.",
 };
 
+export const AVAILABILITY = {
+  short: "Open to remote roles + consulting",
+  full: "Open to remote roles and select backend architecture consulting.",
+};
+
+export const OPERATING_SIGNALS = [
+  { label: "12+ yrs", value: "production software" },
+  { label: ".NET + Azure", value: "primary lane" },
+  { label: "Remote", value: "Brazil to US teams" },
+  { label: "Systems", value: "architecture + delivery" },
+];
+
+export const ENGINEERING_PRINCIPLES = [
+  {
+    title: "Reliability before theater",
+    body: "Prefer observable, recoverable systems over clever code that nobody wants to own at 2am.",
+  },
+  {
+    title: "Boundaries with a reason",
+    body: "Use CQRS, DDD, microservices, and hexagonal architecture when they reduce real operational cost.",
+  },
+  {
+    title: "Delivery is part of design",
+    body: "CI/CD, small releases, and clear feedback loops keep architecture honest after the diagram is gone.",
+  },
+];
+
 export const SKILLS = {
   languages: ["C#", "Rust", "Go", "Python", "TypeScript", "JavaScript"],
   backend: [".NET Core+", "ASP.NET Core", "Entity Framework", "MAUI", "Blazor"],

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,29 +1,29 @@
 @import "tailwindcss";
 
 @theme {
-  --color-bg: #0a0a0f;
-  --color-surface: #111118;
-  --color-elevated: #18181f;
-  --color-border: #242430;
-  --color-border-hover: #363648;
-  --color-text: #f2f2f8;
-  --color-muted: #9090a8;
-  --color-dim: #505068;
-  --color-violet: #4ade80;
-  --color-violet-light: #86efac;
-  --color-violet-dim: #22c55e;
-  --color-violet-tint: rgba(74, 222, 128, 0.08);
-  --color-violet-glow: rgba(74, 222, 128, 0.15);
-  --color-green: #4ade80;
-  --color-green-dim: #22c55e;
-  --color-green-tint: rgba(74, 222, 128, 0.08);
-  --color-purple: #c084fc;
-  --color-cyan: #22d3ee;
-  --color-yellow: #fbbf24;
-  --color-rose: #fb7185;
-  --color-amber: #f59e0b;
+  --color-bg: oklch(11% 0.02 145);
+  --color-surface: oklch(15% 0.025 150);
+  --color-elevated: oklch(20% 0.03 154);
+  --color-border: oklch(29% 0.035 154);
+  --color-border-hover: oklch(39% 0.05 154);
+  --color-text: oklch(94% 0.025 145);
+  --color-muted: oklch(73% 0.035 150);
+  --color-dim: oklch(52% 0.035 150);
+  --color-violet: oklch(76% 0.18 151);
+  --color-violet-light: oklch(86% 0.16 151);
+  --color-violet-dim: oklch(58% 0.17 151);
+  --color-violet-tint: oklch(76% 0.18 151 / 0.08);
+  --color-violet-glow: oklch(76% 0.18 151 / 0.18);
+  --color-green: oklch(76% 0.18 151);
+  --color-green-dim: oklch(58% 0.17 151);
+  --color-green-tint: oklch(76% 0.18 151 / 0.08);
+  --color-purple: oklch(75% 0.16 310);
+  --color-cyan: oklch(79% 0.14 205);
+  --color-yellow: oklch(83% 0.15 88);
+  --color-rose: oklch(72% 0.17 18);
+  --color-amber: oklch(78% 0.16 68);
   --font-sans: "DM Sans", -apple-system, system-ui, sans-serif;
-  --font-display: "DM Serif Display", serif;
+  --font-display: "DM Sans", -apple-system, system-ui, sans-serif;
   --font-mono: "JetBrains Mono", "Fira Code", monospace;
 }
 
@@ -328,4 +328,577 @@ body::after {
   background: linear-gradient(90deg, transparent 0%, var(--color-violet) 30%, var(--color-violet-light) 60%, transparent 100%);
   opacity: 0.4;
   margin-bottom: 2rem;
+}
+
+/* ── Developerish operating manual variant ── */
+:where(a, button, input):focus-visible {
+  outline: 2px solid var(--color-green);
+  outline-offset: 4px;
+}
+
+body {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 70% 0%, oklch(76% 0.18 151 / 0.12), transparent 34rem),
+    linear-gradient(135deg, oklch(9% 0.018 145), var(--color-bg) 42%, oklch(14% 0.024 170));
+}
+
+body::before {
+  opacity: 0.045;
+}
+
+body::after {
+  background-image:
+    linear-gradient(oklch(76% 0.18 151 / 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, oklch(76% 0.18 151 / 0.035) 1px, transparent 1px);
+  background-size: 48px 48px;
+  mask-image: linear-gradient(to bottom, transparent 0%, black 14%, black 86%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 14%, black 86%, transparent 100%);
+}
+
+.site-shell {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
+}
+
+.route-nav {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 0;
+  backdrop-filter: blur(18px);
+}
+
+.route-mark {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  font-weight: 800;
+  color: var(--color-text);
+  letter-spacing: 0.08em;
+}
+.route-mark span { color: var(--color-green); }
+
+.route-links {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.7rem, 2vw, 1.4rem);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+.route-links a {
+  color: var(--color-muted);
+  transition: color 180ms ease, background 180ms ease;
+}
+.route-links a:hover { color: var(--color-text); }
+.route-resume {
+  color: var(--color-bg) !important;
+  background: var(--color-green);
+  border: 1px solid var(--color-green);
+  border-radius: 999px;
+  padding: 0.45rem 0.75rem;
+}
+.route-resume:hover { background: var(--color-violet-light); }
+
+.kernel-hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(320px, 0.92fr);
+  align-items: center;
+  gap: clamp(2rem, 6vw, 5rem);
+  min-height: auto;
+  padding: clamp(2rem, 5vw, 4rem) 0 clamp(2rem, 5vw, 4rem);
+}
+.scanline {
+  position: absolute;
+  inset: 7% -12% auto;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, oklch(76% 0.18 151 / 0.45), transparent);
+  box-shadow: 0 0 52px oklch(76% 0.18 151 / 0.24);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  border: 1px solid oklch(76% 0.18 151 / 0.25);
+  border-radius: 999px;
+  background: oklch(76% 0.18 151 / 0.08);
+  color: var(--color-green);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  padding: 0.42rem 0.72rem;
+  margin-bottom: 1.5rem;
+}
+.status-pill span {
+  width: 0.48rem;
+  height: 0.48rem;
+  border-radius: 999px;
+  background: var(--color-green);
+  box-shadow: 0 0 18px var(--color-green);
+}
+
+.kernel-hero h1 {
+  max-width: 11ch;
+  color: var(--color-text);
+  font-family: var(--font-display);
+  font-size: clamp(3.8rem, 11vw, 9rem);
+  font-weight: 900;
+  letter-spacing: -0.085em;
+  line-height: 0.82;
+}
+.role-line {
+  min-height: 2rem;
+  margin-top: 1.4rem;
+  font-family: var(--font-mono);
+  font-size: clamp(1rem, 2vw, 1.3rem);
+  color: var(--color-green);
+}
+.hero-lede {
+  max-width: 62ch;
+  margin-top: 1.4rem;
+  color: var(--color-muted);
+  font-size: clamp(1.04rem, 2vw, 1.22rem);
+  line-height: 1.75;
+}
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 2rem;
+}
+.primary-action,
+.secondary-action,
+.ghost-action {
+  border-radius: 0.8rem;
+  border: 1px solid var(--color-border);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 800;
+  padding: 0.8rem 1rem;
+  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+.primary-action {
+  color: var(--color-bg);
+  background: var(--color-green);
+  border-color: var(--color-green);
+}
+.secondary-action, .ghost-action {
+  color: var(--color-text);
+  background: oklch(94% 0.025 145 / 0.035);
+}
+.ghost-action { cursor: pointer; }
+.primary-action:hover,
+.secondary-action:hover,
+.ghost-action:hover {
+  transform: translateY(-2px);
+  border-color: var(--color-green);
+}
+.signal-strip {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.55rem;
+  margin-top: 2rem;
+  max-width: 680px;
+}
+.signal-strip span {
+  border: 1px solid oklch(94% 0.025 145 / 0.08);
+  border-radius: 0.85rem;
+  padding: 0.8rem;
+  background: oklch(94% 0.025 145 / 0.025);
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+.signal-strip b {
+  display: block;
+  color: var(--color-text);
+  font-size: 0.9rem;
+  margin-bottom: 0.18rem;
+}
+
+.hero-console-wrap { min-width: 0; }
+.hero-console {
+  border: 1px solid oklch(76% 0.18 151 / 0.24);
+  border-radius: 1.25rem;
+  background:
+    linear-gradient(180deg, oklch(94% 0.025 145 / 0.055), transparent),
+    oklch(12% 0.024 150 / 0.92);
+  box-shadow: 0 26px 90px oklch(3% 0.02 150 / 0.55), inset 0 1px 0 oklch(94% 0.025 145 / 0.08);
+  overflow: hidden;
+}
+.console-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid oklch(94% 0.025 145 / 0.08);
+  padding: 0.9rem 1rem;
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+.console-state { color: var(--color-green); }
+.hero-console pre {
+  margin: 0;
+  padding: clamp(1rem, 3vw, 1.5rem);
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: clamp(0.72rem, 1.7vw, 0.92rem);
+  line-height: 1.8;
+  white-space: pre-wrap;
+}
+
+.content-section {
+  padding: clamp(4rem, 9vw, 7rem) 0;
+}
+.section-bridge + .content-section {
+  padding-top: clamp(1.2rem, 3vw, 2.2rem);
+}
+.split-section {
+  display: grid;
+  grid-template-columns: 0.72fr 1.28fr;
+  gap: clamp(2rem, 6vw, 5rem);
+}
+.section-ruler {
+  position: sticky;
+  top: 5rem;
+  align-self: start;
+}
+.section-heading {
+  margin-top: 0.45rem;
+  color: var(--color-text);
+  font-size: clamp(1.9rem, 4vw, 3.6rem);
+  font-weight: 900;
+  letter-spacing: -0.06em;
+  line-height: 0.95;
+}
+.packet-card {
+  color: var(--color-muted);
+  font-size: clamp(1rem, 2vw, 1.16rem);
+  line-height: 1.78;
+  max-width: 70ch;
+}
+.packet-card p + p { margin-top: 1rem; }
+.principle-grid {
+  grid-column: 2;
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.2rem;
+}
+.principle-row {
+  display: grid;
+  grid-template-columns: 3rem 1fr;
+  gap: 1rem;
+  border-top: 1px solid var(--color-border);
+  padding-top: 1rem;
+}
+.principle-row > span {
+  color: var(--color-green);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+}
+.principle-row h3,
+.capability-row h3,
+.trace-body h3,
+.workbench-card h3 {
+  color: var(--color-text);
+  font-weight: 850;
+  letter-spacing: -0.02em;
+}
+.principle-row p,
+.trace-body p,
+.workbench-card p,
+.repo-row p { color: var(--color-muted); line-height: 1.65; }
+
+.capability-grid {
+  display: grid;
+  gap: 0.7rem;
+}
+.capability-row {
+  display: grid;
+  grid-template-columns: minmax(150px, 0.45fr) minmax(180px, 0.6fr) 1fr;
+  gap: 1rem;
+  align-items: start;
+  border: 1px solid var(--color-border);
+  border-radius: 1rem;
+  background: oklch(94% 0.025 145 / 0.026);
+  padding: 1rem;
+}
+.capability-row > p {
+  color: var(--color-dim);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+.capability-row div,
+.project-tags,
+.trace-body div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.42rem;
+}
+.capability-row span,
+.project-tags span,
+.trace-body div span {
+  border: 1px solid oklch(76% 0.18 151 / 0.18);
+  border-radius: 999px;
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  padding: 0.3rem 0.55rem;
+}
+
+.trace-list {
+  display: grid;
+  gap: 0.8rem;
+}
+.trace-entry {
+  display: grid;
+  grid-template-columns: minmax(190px, 0.36fr) 1fr;
+  gap: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 1.1rem;
+  padding: 1rem;
+  background: oklch(94% 0.025 145 / 0.024);
+}
+.trace-entry.current {
+  border-color: oklch(76% 0.18 151 / 0.28);
+  background: oklch(76% 0.18 151 / 0.065);
+}
+.trace-meta {
+  color: var(--color-dim);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+.trace-meta span {
+  display: block;
+  color: var(--color-green);
+  margin-bottom: 0.5rem;
+}
+.trace-location {
+  margin: 0.18rem 0 0.8rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+}
+.trace-body h3 span { color: var(--color-muted); font-weight: 500; }
+.trace-body div { margin-top: 0.85rem; }
+
+.workbench-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 1rem;
+}
+.workbench-grid > .reveal:nth-child(1),
+.workbench-grid > .reveal:nth-child(4) { grid-column: span 3; }
+.workbench-grid > .reveal:nth-child(2),
+.workbench-grid > .reveal:nth-child(3),
+.workbench-grid > .reveal:nth-child(5) { grid-column: span 2; }
+.workbench-card {
+  min-height: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 1.15rem;
+  background: linear-gradient(180deg, oklch(94% 0.025 145 / 0.04), oklch(94% 0.025 145 / 0.018));
+  padding: 1.1rem;
+  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+.workbench-card:hover {
+  transform: translateY(-3px);
+  border-color: oklch(76% 0.18 151 / 0.3);
+  background: oklch(94% 0.025 145 / 0.045);
+}
+.card-head {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-bottom: 1rem;
+}
+.card-head span {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 999px;
+}
+.card-head p {
+  color: var(--color-dim);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+.workbench-card > p { margin: 0.7rem 0 1rem; }
+.project-actions {
+  display: flex;
+  gap: 0.7rem;
+  margin-top: 1.1rem;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+}
+.project-actions a,
+.github-tail {
+  color: var(--color-green);
+}
+
+.repo-table {
+  display: grid;
+  border-top: 1px solid var(--color-border);
+}
+.repo-row {
+  display: grid;
+  grid-template-columns: minmax(180px, 0.45fr) 1fr minmax(140px, 0.25fr);
+  gap: 1rem;
+  border-bottom: 1px solid var(--color-border);
+  padding: 1rem 0;
+}
+.repo-row > a {
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: 0.86rem;
+}
+.repo-row div {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.4rem;
+  color: var(--color-dim);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+}
+.repo-row div a { color: var(--color-green); }
+.github-tail {
+  display: inline-flex;
+  margin-top: 1.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+}
+
+.site-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  border-top: 1px solid var(--color-border);
+  padding: 2rem 0 4rem;
+  color: var(--color-dim);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+.footer-socials {
+  display: flex;
+  gap: 0.6rem;
+}
+.icon-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--color-muted);
+  transition: color 180ms ease;
+}
+.icon-link:hover { color: var(--color-green); }
+.icon-link svg { width: 1rem; height: 1rem; }
+.icon-link.compact span { display: none; }
+
+.terminal-dialog {
+  width: min(720px, 100%);
+  overflow: hidden;
+  border: 1px solid oklch(76% 0.18 151 / 0.28);
+  border-radius: 1rem;
+  background: var(--color-bg);
+  box-shadow: 0 30px 100px oklch(3% 0.02 150 / 0.72);
+}
+.terminal-titlebar {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface);
+  padding: 0.8rem 1rem;
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+}
+.terminal-titlebar button {
+  margin-left: auto;
+  color: var(--color-green);
+  cursor: pointer;
+}
+.window-dots { display: flex; gap: 0.35rem; }
+.window-dots span {
+  width: 0.62rem;
+  height: 0.62rem;
+  border-radius: 999px;
+  background: var(--color-border-hover);
+}
+.terminal-body {
+  height: 24rem;
+  overflow-y: auto;
+  padding: 1rem;
+  background: var(--color-bg);
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+}
+.cmd-line { color: var(--color-green); white-space: pre-wrap; }
+.out-line { color: var(--color-muted); white-space: pre-wrap; line-height: 1.7; }
+.terminal-input-row {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--color-green);
+}
+.terminal-input-row input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  color: var(--color-text);
+  outline: none;
+}
+
+@media (max-width: 900px) {
+  .kernel-hero,
+  .split-section,
+  .trace-entry,
+  .repo-row,
+  .capability-row {
+    grid-template-columns: 1fr;
+  }
+  .principle-grid { grid-column: auto; }
+  .section-ruler { position: static; }
+  .workbench-grid { grid-template-columns: 1fr; }
+  .workbench-grid > .reveal { grid-column: auto !important; }
+  .repo-row div { justify-content: flex-start; }
+}
+
+@media (max-width: 640px) {
+  .site-shell { width: min(100% - 24px, 1180px); }
+  .route-nav { align-items: flex-start; }
+  .route-links { flex-wrap: wrap; justify-content: flex-end; }
+  .kernel-hero h1 { font-size: clamp(3.7rem, 22vw, 6.5rem); }
+  .signal-strip { grid-template-columns: 1fr; }
+  .hero-actions a, .hero-actions button { width: 100%; text-align: center; justify-content: center; }
+  .site-footer { flex-direction: column; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+  .reveal { opacity: 1; transform: none; }
+}
+
+.section-bridge {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-dim);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  padding: 0.85rem 0;
+}
+.section-bridge span:first-child {
+  color: var(--color-green);
 }


### PR DESCRIPTION
## Summary
- Reworks the portfolio into a darker developer/system-console aesthetic.
- Adds route-style navigation, a YAML deploy ledger hero panel, operating signal chips, profile/capability/trace sections, and refreshed project/repository cards.
- Keeps the hidden shell interaction and adds a visible Open shell CTA.

## Test Plan
- [x] `mise exec -- bun run lint`
- [x] `mise exec -- bun run build`
- [x] `npx impeccable detect --json src/components/Portfolio.tsx src/pages/index.astro`
- [x] `git diff --check`
- [x] Browser preview smoke check, including shell hydration
