### PR TITLE
fix: keep shell as hidden easter egg

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -186,7 +186,7 @@ The layout should read like a technical dossier:
 3. **Capability map:** stack grouped by language, backend, architecture, cloud, data, and frontend.
 4. **Experience trace:** chronological production history with the current role visually elevated.
 5. **Workbench:** curated featured projects before dynamic repository tail.
-6. **Repository tail and footer:** more proof, socials, and shell/easter-egg affordances.
+6. **Repository tail and footer:** more proof and socials, without exposing the shell trigger.
 
 Spacing should be generous enough to feel calm, but dense enough to preserve a systems-console rhythm. Prefer grids, ledgers, and cards over large decorative illustrations.
 
@@ -231,11 +231,11 @@ Tags are metadata, not decoration. Use them to make stack and domain fit scannab
 
 ### Terminal / shell
 
-The shell is a progressive enhancement and personality layer. It must not be the only way to access resume, contact, stack, or availability information. Keyboard behavior should be predictable: `Enter` submits, `Escape` closes, and focus is visible.
+The shell is a progressive enhancement and personality layer. It is an easter egg, not a visible feature: do not add an "open shell" button, footer instruction, or explicit activation hint in the primary UI. It must not be the only way to access resume, contact, stack, or availability information. Keyboard behavior should be predictable after discovery: `Enter` submits, `Escape` closes, and focus is visible.
 
 ### CTAs
 
-Primary CTA: resume/contact/hire path. Secondary CTA: GitHub, LinkedIn, project links, or open shell. CTAs should use clear verbs and preserve native link behavior.
+Primary CTA: resume/contact/hire path. Secondary CTA: GitHub, LinkedIn, and project links. Do not expose the shell as a CTA. CTAs should use clear verbs and preserve native link behavior.
 
 ## Do's and Don'ts
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -80,7 +80,7 @@ Supporting signals:
 ### Curious developer path
 
 1. Notice the console/runbook aesthetic.
-2. Open the interactive shell or find the easter egg.
+2. Discover the interactive shell only through the easter egg.
 3. Explore repositories and social links.
 
 ## Functional Requirements
@@ -90,7 +90,7 @@ Supporting signals:
 - Build-time GitHub project fetching where configured, with safe fallbacks.
 - Resume route and/or resume CTA available from primary navigation.
 - Contact/social links available in hero/footer and keyboard/screen-reader accessible.
-- Hidden shell/easter egg preserved as progressive enhancement; core content must remain useful without it.
+- Hidden shell/easter egg preserved as progressive enhancement; it must not have a visible CTA or explicit activation instructions in the primary UI, and core content must remain useful without it.
 - Analytics events may track outbound/social/resume interactions, but must not block navigation.
 
 ## Non-Goals

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -247,12 +247,6 @@ export default function Portfolio({ projects }: { projects: GitHubRepo[] }) {
     [closeTerminal, cmdHist, histIdx, submit],
   );
 
-  const openTerminal = () => {
-    lastFocusedRef.current = document.activeElement as HTMLElement | null;
-    setTermOpen(true);
-    trackEvent("terminal_open", { source: "hero" });
-  };
-
   return (
     <>
       <div className="scroll-bar fixed top-0 left-0 right-0 h-[2px] z-50" style={{ transform: `scaleX(${scrollProgress})` }} />
@@ -285,7 +279,6 @@ export default function Portfolio({ projects }: { projects: GitHubRepo[] }) {
               <div className="hero-actions">
                 <a href="/resume" className="primary-action" onClick={() => trackEvent("cta_click", { label: "hero_resume" })}>View resume</a>
                 <a href="https://www.linkedin.com/in/jonathan-peris/" target="_blank" rel="noreferrer noopener" className="secondary-action" onClick={() => trackEvent("cta_click", { label: "hero_linkedin" })}>Contact on LinkedIn</a>
-                <button type="button" className="ghost-action" onClick={openTerminal}>Open shell</button>
               </div>
               <div className="signal-strip" aria-label="Operating signals">
                 {OPERATING_SIGNALS.map((signal) => (
@@ -433,7 +426,7 @@ export default function Portfolio({ projects }: { projects: GitHubRepo[] }) {
           <div className="footer-socials">
             {SOCIALS.map((social) => <SocialLink key={social.label} social={social} compact />)}
           </div>
-          <p>Built as a small systems manual. Hidden shell: ↑↑↓↓←→←→BA</p>
+          <p>Built as a small systems manual.</p>
         </footer>
       </div>
 


### PR DESCRIPTION
## Summary
- Removes the visible `Open shell` hero button so the terminal remains a hidden easter egg only.
- Removes the footer activation hint from the public UI.
- Updates PRODUCT.md and DESIGN.md guardrails to keep the shell hidden from primary CTAs/UI.

## Test Plan
- [x] No `Open shell` / explicit hidden-shell hint remains in `src/components/Portfolio.tsx`
- [x] `npx -y @google/design.md lint DESIGN.md`
- [x] `mise exec -- bun run lint`
- [x] `mise exec -- bun run build`
- [x] `git diff --check`
