### PR TITLE
fix: restore hidden shell footer hint

### DIFF
--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -426,7 +426,7 @@ export default function Portfolio({ projects }: { projects: GitHubRepo[] }) {
           <div className="footer-socials">
             {SOCIALS.map((social) => <SocialLink key={social.label} social={social} compact />)}
           </div>
-          <p>Built as a small systems manual.</p>
+          <p>Built as a small systems manual. Hidden shell: ↑↑↓↓←→←→BA</p>
         </footer>
       </div>
 


### PR DESCRIPTION
## Summary
- Restores the footer hint for the hidden shell Konami-code easter egg.
- Keeps the visible hero `Open shell` button removed.

## Test Plan
- [x] `mise exec -- bun run lint`
- [x] `mise exec -- bun run build`
- [x] `git diff --check`
